### PR TITLE
8298402: ProblemList javax/swing/JFileChooser/4847375/bug4847375.java on windows-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -165,3 +165,4 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
 vmTestbase/nsk/stress/except/except012.java 8297977 generic-all
+vmTestbase/nsk/stress/strace/strace004.java 8297824 macosx-x64,windows-x64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -166,3 +166,4 @@ vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEa
 
 vmTestbase/nsk/stress/except/except012.java 8297977 generic-all
 vmTestbase/nsk/stress/strace/strace004.java 8297824 macosx-x64,windows-x64
+vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -80,6 +80,7 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293,8298073 macosx-x64,macosx-aarch64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
+gc/TestFullGCCount.java 8298296 linux-x64
 
 #############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -672,6 +672,7 @@ javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
 java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8297296 macosx-all
 javax/swing/JFileChooser/8046391/bug8046391.java 8293862 windows-x64
+javax/swing/JFileChooser/4847375/bug4847375.java 8293862 windows-x64
 java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64
 java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java 8294264 windows-x64
 java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java 8253184,8295813 windows-x64


### PR DESCRIPTION
A trivial fix for several ProblemListings:
[JDK-8298402](https://bugs.openjdk.org/browse/JDK-8298402) ProblemList javax/swing/JFileChooser/4847375/bug4847375.java on windows-x64
[JDK-8298414](https://bugs.openjdk.org/browse/JDK-8298414) ProblemList gc/TestFullGCCount.java on linux-x64
[JDK-8298417](https://bugs.openjdk.org/browse/JDK-8298417) ProblemList vmTestbase/nsk/stress/strace/strace004.java on 2 platforms
[JDK-8298419](https://bugs.openjdk.org/browse/JDK-8298419) ProblemList vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java on windows-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298402](https://bugs.openjdk.org/browse/JDK-8298402): ProblemList javax/swing/JFileChooser/4847375/bug4847375.java on windows-x64
 * [JDK-8298414](https://bugs.openjdk.org/browse/JDK-8298414): ProblemList gc/TestFullGCCount.java on linux-x64
 * [JDK-8298417](https://bugs.openjdk.org/browse/JDK-8298417): ProblemList vmTestbase/nsk/stress/strace/strace004.java on 2 platforms
 * [JDK-8298419](https://bugs.openjdk.org/browse/JDK-8298419): ProblemList vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java on windows-x64


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.org/jdk20 pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/1.diff">https://git.openjdk.org/jdk20/pull/1.diff</a>

</details>
