### PR TITLE
8298225: [AIX] Disable PPC64LE continuations on AIX

### DIFF
--- a/src/hotspot/cpu/ppc/globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globals_ppc.hpp
@@ -54,7 +54,7 @@ define_pd_global(intx, StackRedPages,         DEFAULT_STACK_RED_PAGES);
 define_pd_global(intx, StackShadowPages,      DEFAULT_STACK_SHADOW_PAGES);
 define_pd_global(intx, StackReservedPages,    DEFAULT_STACK_RESERVED_PAGES);
 
-define_pd_global(bool,  VMContinuations, true);
+define_pd_global(bool,  VMContinuations, AIX_ONLY(false) NOT_AIX(true));
 
 // Use large code-entry alignment.
 define_pd_global(uintx, CodeCacheSegmentSize,  128);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -14375,7 +14375,9 @@ instruct safePoint_poll(iRegPdst poll) %{
 // Call Java Static Instruction
 
 source %{
-  #include "runtime/continuation.hpp"
+
+#include "runtime/continuation.hpp"
+
 %}
 
 // Schedulable version of call static node.

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -14374,6 +14374,10 @@ instruct safePoint_poll(iRegPdst poll) %{
 
 // Call Java Static Instruction
 
+source %{
+  #include "runtime/continuation.hpp"
+%}
+
 // Schedulable version of call static node.
 instruct CallStaticJavaDirect(method meth) %{
   match(CallStaticJava);


### PR DESCRIPTION
This small change adds an import to ppc.ad to allow it to find Contiuations::enabled, and sets VMContinuations to false on AIX.

Thanks to @TheRealMDoerr for suggestions to a previous version of this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298225](https://bugs.openjdk.org/browse/JDK-8298225): [AIX] Disable PPC64LE continuations on AIX


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**) ⚠️ Review applies to [74c36006](https://git.openjdk.org/jdk20/pull/4/files/74c36006675b20ce1f8b1900c2a5e358f1e03baa)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/jdk20 pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/4.diff">https://git.openjdk.org/jdk20/pull/4.diff</a>

</details>
