### PR TITLE
8298324: Unable to run shell test with make

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -352,7 +352,7 @@ ExpandJtregPath = \
 # with test id: dir/Test.java#selection -> Test.java#selection -> .java#selection -> #selection
 #      without: dir/Test.java           -> Test.java           -> .java           -> <<empty string>>
 TestID = \
-    $(subst .java,,$(suffix $(notdir $1)))
+    $(subst .sh,,$(subst .html,,$(subst .java,,$(suffix $(notdir $1)))))
 
 # The test id starting with a hash (#testid) will be stripped by all
 # evals in ParseJtregTestSelectionInner and will be reinserted by calling


### PR DESCRIPTION
The parsing of the TestID in the TEST parameter currently only handles tests that are .java files. Jtreg tests can also be .html and .sh files. This patch extends the macro to also handle these kinds of files.

Without the patch, trying to run a shell test directly would fail like this:

```
$ make test TEST=open/test/jdk/sun/security/tools/keytool/ListKeychainStore.sh
Building target 'test' in configuration 'linux-x64'
Test selection 'open/test/jdk/sun/security/tools/keytool/ListKeychainStore.sh', will run:
* jtreg:open/test/jdk/sun/security/tools/keytool/ListKeychainStore.sh.sh

Running test 'jtreg:open/test/jdk/sun/security/tools/keytool/ListKeychainStore.sh.sh'
Error: Cannot find file: open/test/jdk/sun/security/tools/keytool/ListKeychainStore.sh.sh
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298324](https://bugs.openjdk.org/browse/JDK-8298324): Unable to run shell test with make


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/jdk20 pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/5.diff">https://git.openjdk.org/jdk20/pull/5.diff</a>

</details>
