### PR TITLE
8298455: JFR: Add logging to TestClose.java

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestClose.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestClose.java
@@ -38,7 +38,7 @@ import jdk.jfr.consumer.RecordingStream;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.api.consumer.recordingstream.TestClose
+ * @run main/othervm -Xlog:jfr+streaming+system=trace jdk.jfr.api.consumer.recordingstream.TestClose
  */
 public class TestClose {
 


### PR DESCRIPTION
Hi,

Could I have a review of a test fix. 

The test jdk/jfr/api/consumer/recordingstream/TestClose.java times out intermittently, but the thread dump looks fine. One possibility is that the onEvent action is never registered. It would be good to verify that the registration mechanism works properly. This can be done by logging with -Xlog:jfr+streaming+system=trace

Testing: running test locally

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298455](https://bugs.openjdk.org/browse/JDK-8298455): JFR: Add logging to TestClose.java


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/jdk20 pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/7.diff">https://git.openjdk.org/jdk20/pull/7.diff</a>

</details>
