### PR TITLE
JDK-8289748: C2 compiled code crashes with SIGFPE with -XX:+StressLCM and -XX:+StressGCM

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
@@ -26,7 +26,7 @@
 * @bug 8289748
 * @summary SIGFPE caused by C2 IdealLoopTree::do_remove_empty_loop
 *
-* @run main/othervm -XX:-TieredCompilation -Xcomp -XX:+UseG1GC
+* @run main/othervm -XX:-TieredCompilation -Xcomp
 *                   -XX:CompileOnly=compiler.loopopts.TestRemoveEmptyCountedLoop::test
 *                   compiler.loopopts.TestRemoveEmptyCountedLoop
 */

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @bug 8289748
+* @summary SIGFPE caused by C2 IdealLoopTree::do_remove_empty_loop
+*
+* @run main/othervm -XX:-TieredCompilation -Xcomp -XX:+UseG1GC
+*                   -XX:CompileOnly=compiler.loopopts.TestRemoveEmptyCountedLoop::test
+*                   compiler.loopopts.TestRemoveEmptyCountedLoop
+*/
+
+package compiler.loopopts;
+
+public class TestRemoveEmptyCountedLoop {
+
+    public void test() {
+        int k = 3;
+        for (int i=9; i>0; i--) {
+            int j = 2;
+            do {
+                try {
+                    k = k;
+                    k = (1 % j);
+                } catch (Exception e) {}
+            } while (++j < i);
+        }
+    }
+
+    public static void main(String[] args) {
+        TestRemoveEmptyCountedLoop _instance = new TestRemoveEmptyCountedLoop();
+        _instance.test();
+        System.out.println("Test passed.");
+    }
+}


### PR DESCRIPTION
# Problem

`203 CountedLoop` is the post loop of a strip-mined inner loop. In the loop we have `198 ModI` = 1 / tripcount, where tripcount can never be zero in this loop. The tripcount `204 Phi` is further pinned with a `224 CastII`.

<img width="457" alt="before" src="https://user-images.githubusercontent.com/71546117/206709381-875a24f1-9d78-47d4-95d9-d844714edc09.png">

`IdealLoopTree::do_remove_empty_loop(...)` now replaces the tripcounter `204 Phi` with the value that the loop will have on the last iteration: `80 Phi` (exact limit) - `Const 1` (stride). Here is where the mistake happens: 
`222 If` is the zero trip guard of the post loop and prevents that the post loop is executed when the divisor of `198 ModI` would be zero. BUT tripcounter `204 Phi` is removed without checking if it is pinned to the IF with a CastNode. Therefore the `198 ModI` now floats above the `222 if` where it now can be a modulo zero operation.  

<img width="267" alt="fail" src="https://user-images.githubusercontent.com/71546117/206709403-91480599-a310-4da0-b8ab-6e49527141db.png">

# Solution
The Solution is to check if the tripcount is pinned with a CastII that carries a dependency. If Yes, we create a new CastII to pin final_iv (exact_ limit - stride) :
<img width="416" alt="fix" src="https://user-images.githubusercontent.com/71546117/206709431-60f0d104-1e4e-416a-8ee1-225435c82e7c.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289748](https://bugs.openjdk.org/browse/JDK-8289748): C2 compiled code crashes with SIGFPE with -XX:+StressLCM and -XX:+StressGCM


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jdk20 pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/8.diff">https://git.openjdk.org/jdk20/pull/8.diff</a>

</details>
