### PR TITLE
8298459: Fix msys2 linking and handling out of tree build directory for source zip creation

### DIFF
--- a/make/ZipSource.gmk
+++ b/make/ZipSource.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -33,10 +33,6 @@ include Modules.gmk
 SRC_ZIP_WORK_DIR := $(SUPPORT_OUTPUTDIR)/src
 $(if $(filter $(TOPDIR)/%, $(SUPPORT_OUTPUTDIR)), $(eval SRC_ZIP_BASE := $(TOPDIR)), $(eval SRC_ZIP_BASE := $(SUPPORT_OUTPUTDIR)))
 
-$(info CL TOPDIR: $(TOPDIR))
-$(info CL SUPPORT_OUTPUTDIR: $(SUPPORT_OUTPUTDIR))
-$(info CL SRC_ZIP_BASE: $(SRC_ZIP_BASE))
-
 # Hook to include the corresponding custom file, if present.
 $(eval $(call IncludeCustomExtension, ZipSource.gmk))
 
@@ -50,7 +46,6 @@ ALL_MODULES := $(FindAllModules)
 # again to create src.zip.
 $(foreach m, $(ALL_MODULES), \
   $(foreach d, $(call FindModuleSrcDirs, $m), \
-    $(info CL TARGET: $(SRC_ZIP_WORK_DIR)/$(patsubst $(TOPDIR)/%,%,$(patsubst $(SUPPORT_OUTPUTDIR)/%,%,$d))/$m) \
     $(eval $d_TARGET := $(SRC_ZIP_WORK_DIR)/$(patsubst $(TOPDIR)/%,%,$(patsubst $(SUPPORT_OUTPUTDIR)/%,%,$d))/$m) \
     $(if $(SRC_GENERATED), , \
       $(eval $$($d_TARGET): $d ; \

--- a/make/ZipSource.gmk
+++ b/make/ZipSource.gmk
@@ -31,6 +31,11 @@ include JavaCompilation.gmk
 include Modules.gmk
 
 SRC_ZIP_WORK_DIR := $(SUPPORT_OUTPUTDIR)/src
+$(if $(filter $(TOPDIR)/%, $(SUPPORT_OUTPUTDIR)), $(eval SRC_ZIP_BASE := $(TOPDIR)), $(eval SRC_ZIP_BASE := $(SUPPORT_OUTPUTDIR)))
+
+$(info CL TOPDIR: $(TOPDIR))
+$(info CL SUPPORT_OUTPUTDIR: $(SUPPORT_OUTPUTDIR))
+$(info CL SRC_ZIP_BASE: $(SRC_ZIP_BASE))
 
 # Hook to include the corresponding custom file, if present.
 $(eval $(call IncludeCustomExtension, ZipSource.gmk))
@@ -45,10 +50,11 @@ ALL_MODULES := $(FindAllModules)
 # again to create src.zip.
 $(foreach m, $(ALL_MODULES), \
   $(foreach d, $(call FindModuleSrcDirs, $m), \
-    $(eval $d_TARGET := $(SRC_ZIP_WORK_DIR)/$(patsubst $(TOPDIR)/%,%,$d)/$m) \
+    $(info CL TARGET: $(SRC_ZIP_WORK_DIR)/$(patsubst $(TOPDIR)/%,%,$(patsubst $(SUPPORT_OUTPUTDIR)/%,%,$d))/$m) \
+    $(eval $d_TARGET := $(SRC_ZIP_WORK_DIR)/$(patsubst $(TOPDIR)/%,%,$(patsubst $(SUPPORT_OUTPUTDIR)/%,%,$d))/$m) \
     $(if $(SRC_GENERATED), , \
       $(eval $$($d_TARGET): $d ; \
-          $$(if $(filter $(TOPDIR)/%, $d), $$(link-file-relative), $$(link-file-absolute)) \
+          $$(if $(filter $(SRC_ZIP_BASE)/%, $d), $$(link-file-relative), $$(link-file-absolute)) \
       ) \
     ) \
     $(eval SRC_ZIP_SRCS += $$($d_TARGET)) \

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -306,16 +306,15 @@ endef
 # There are two versions, either creating a relative or an absolute link. Be
 # careful when using this on Windows since the symlink created is only valid in
 # the unix emulation environment.
-# In msys2 we use mklink /J because ln would copy the target file system tree.
-# This inhibits performance and can lead to issues with long paths.
+# In msys2 we use mklink /J because its ln would perform a deep copy of the target.
+# This inhibits performance and can lead to issues with long paths. With mklink /J
+# relative linking does not work, so we handle the link as absolute path.
 define link-file-relative
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
 	if [ "$(OPENJDK_BUILD_OS_ENV)" = "windows.msys2" ]; then \
-	  $(ECHO) "cltrcrel cmd //c \"mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))\""; \
 	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"; \
 	else \
-	  $(ECHO) "cltrcrel $(LN) -s $(call DecodeSpace, $(call RelativePath, $<, $(@D))) $(call DecodeSpace, $@)"; \
 	  $(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'; \
 	fi
 endef
@@ -324,10 +323,8 @@ define link-file-absolute
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
 	if [ "$(OPENJDK_BUILD_OS_ENV)" = "windows.msys2" ]; then \
-	  $(ECHO) "cltrcabs cmd //c \"mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))\""; \
 	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"; \
 	else \
-	  $(ECHO) "cltrcabs $(LN) -s $(call DecodeSpace, $<) $(call DecodeSpace, $@)"; \
 	  $(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'; \
 	fi
 endef

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -306,16 +306,30 @@ endef
 # There are two versions, either creating a relative or an absolute link. Be
 # careful when using this on Windows since the symlink created is only valid in
 # the unix emulation environment.
+# In msys2 we use mklink /J because ln would copy the target file system tree.
+# This inhibits performance and can lead to issues with long paths.
 define link-file-relative
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-	$(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'
+	if [ "$(OPENJDK_BUILD_OS_ENV)" = "windows.msys2" ]; then \
+	  $(ECHO) "cltrcrel cmd //c \"mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))\""; \
+	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"; \
+	else \
+	  $(ECHO) "cltrcrel $(LN) -s $(call DecodeSpace, $(call RelativePath, $<, $(@D))) $(call DecodeSpace, $@)"; \
+	  $(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'; \
+	fi
 endef
 
 define link-file-absolute
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-	$(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
+	if [ "$(OPENJDK_BUILD_OS_ENV)" = "windows.msys2" ]; then \
+	  $(ECHO) "cltrcabs cmd //c \"mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))\""; \
+	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"; \
+	else \
+	  $(ECHO) "cltrcabs $(LN) -s $(call DecodeSpace, $<) $(call DecodeSpace, $@)"; \
+	  $(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'; \
+	fi
 endef
 
 ################################################################################

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -312,21 +312,21 @@ endef
 define link-file-relative
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-    ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
-	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
-    else
-	  $(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'
-    endif
+  ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+	cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
+  else
+	$(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'
+  endif
 endef
 
 define link-file-absolute
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-    ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
-	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
-    else
-	  $(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
-    endif
+  ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+	cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
+  else
+	$(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
+  endif
 endef
 
 ################################################################################

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -309,25 +309,33 @@ endef
 # In msys2 we use mklink /J because its ln would perform a deep copy of the target.
 # This inhibits performance and can lead to issues with long paths. With mklink /J
 # relative linking does not work, so we handle the link as absolute path.
-define link-file-relative
+ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+  define link-file-relative
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-  ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
 	cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
-  else
+  endef
+else
+  define link-file-relative
+	$(call MakeTargetDir)
+	$(RM) '$(call DecodeSpace, $@)'
 	$(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'
-  endif
-endef
+  endef
+endif
 
-define link-file-absolute
+ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+  define link-file-absolute
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-  ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
 	cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
-  else
+  endef
+else
+  define link-file-absolute
+	$(call MakeTargetDir)
+	$(RM) '$(call DecodeSpace, $@)'
 	$(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
-  endif
-endef
+  endef
+endif
 
 ################################################################################
 

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -312,21 +312,21 @@ endef
 define link-file-relative
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-	if [ "$(OPENJDK_BUILD_OS_ENV)" = "windows.msys2" ]; then \
-	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"; \
-	else \
-	  $(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'; \
-	fi
+    ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
+    else
+	  $(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'
+    endif
 endef
 
 define link-file-absolute
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
-	if [ "$(OPENJDK_BUILD_OS_ENV)" = "windows.msys2" ]; then \
-	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"; \
-	else \
-	  $(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'; \
-	fi
+    ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+	  cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
+    else
+	  $(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
+    endif
 endef
 
 ################################################################################


### PR DESCRIPTION
This PR fixes two issues.

In ZipSource.gmk we don't account for the possibility of the build directory or `$(SUPPORT_OUTPUTDIR)` not being in the source directory tree (`$(TOPDIR)`).
It doesn't manifest in a build error though since link-file-relative will then fall back to absolute linking. But it results in awkward paths.

Furthermore, there's a lurking issue in msys2 builds on Windows. There, ln would create deep copies of a file system tree instead of linking. If the file system to be linked contains long paths, it could result in 'File name too long' errors, like can be seen [here](https://github.com/gdams/jdk11u-dev/actions/runs/3563481453/jobs/5986319107). We can avoid this by calling Windows mklink to create a file system junction. Presumably that would also help build performance (though not verified).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298459](https://bugs.openjdk.org/browse/JDK-8298459): Fix msys2 linking and handling out of tree build directory for source zip creation


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.org/jdk20 pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/9.diff">https://git.openjdk.org/jdk20/pull/9.diff</a>

</details>
