### PR TITLE
8298425: System.console().readLine() hangs in jshell

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
@@ -48,6 +48,7 @@ import com.sun.jdi.StackFrame;
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.VirtualMachine;
+import java.util.stream.Stream;
 import jdk.jshell.spi.ExecutionControl;
 import jdk.jshell.spi.ExecutionEnv;
 import static jdk.jshell.execution.Util.remoteInputOutput;
@@ -96,10 +97,15 @@ public class JdiDefaultExecutionControl extends JdiExecutionControl {
             // timeout on I/O-socket
             listener.setSoTimeout(timeout);
             int port = listener.getLocalPort();
+            List<String> augmentedremoteVMOptions =
+                    Stream.concat(env.extraRemoteVMOptions().stream(),
+                                  //disable System.console():
+                                  List.of("-Djdk.console=java.base").stream())
+                          .toList();
 
             // Set-up the JDI connection
             JdiInitiator jdii = new JdiInitiator(port,
-                    env.extraRemoteVMOptions(), remoteAgent, isLaunch, host,
+                    augmentedremoteVMOptions, remoteAgent, isLaunch, host,
                     timeout, Collections.emptyMap());
             VirtualMachine vm = jdii.vm();
             Process process = jdii.process();

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
@@ -58,6 +58,8 @@ public class RemoteExecutionControl extends DirectExecutionControl implements Ex
      * @throws Exception any unexpected exception
      */
     public static void main(String[] args) throws Exception {
+        //disable System.console()
+        System.setProperty("jdk.console", "java.base");
         String loopBack = null;
         Socket socket = new Socket(loopBack, Integer.parseInt(args[0]));
         InputStream inStream = socket.getInputStream();

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
@@ -58,8 +58,6 @@ public class RemoteExecutionControl extends DirectExecutionControl implements Ex
      * @throws Exception any unexpected exception
      */
     public static void main(String[] args) throws Exception {
-        //disable System.console()
-        System.setProperty("jdk.console", "java.base");
         String loopBack = null;
         Socket socket = new Socket(loopBack, Integer.parseInt(args[0]));
         InputStream inStream = socket.getInputStream();

--- a/test/langtools/jdk/jshell/ConsoleTest.java
+++ b/test/langtools/jdk/jshell/ConsoleTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8298425
+ * @summary Verify behavior of System.console()
+ * @build KullaTesting TestingInputStream
+ * @run testng ConsoleTest
+ */
+
+
+import org.testng.annotations.Test;
+
+public class ConsoleTest extends KullaTesting {
+
+    @Test
+    public void testConsole1() {
+        assertEval("System.console()", "null");
+    }
+
+}


### PR DESCRIPTION
After https://bugs.openjdk.org/browse/JDK-8295803, JShell snippets like:
```
jshell> System.console().readLine()
```

hang, as the JLine console is used, and it cannot correctly read from the console while in the remote agent (due to input/output redirection setup for the agent). Until [JDK-8296454](https://bugs.openjdk.org/browse/JDK-8296454) is resolved, the JLine console should be disabled inside the remote agent.

As the default console requires an attached terminal, and there is no attached terminal inside the agent, `System.console()` should then return `null` inside the JShell's agent, which was the behavior before JDK-8295803.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298425](https://bugs.openjdk.org/browse/JDK-8298425): System.console().readLine() hangs in jshell


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [2404e4e2](https://git.openjdk.org/jdk20/pull/11/files/2404e4e2b9cb0266a00828d3f9f30ec9d3e9ba96)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/jdk20 pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/11.diff">https://git.openjdk.org/jdk20/pull/11.diff</a>

</details>
