### PR TITLE
8298463: tools/javac/modules/EdgeCases.java fails on Windows after JDK-8297988

### DIFF
--- a/test/langtools/tools/javac/modules/EdgeCases.java
+++ b/test/langtools/tools/javac/modules/EdgeCases.java
@@ -39,6 +39,7 @@
 import java.io.BufferedWriter;
 import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -1079,6 +1080,7 @@ public class EdgeCases extends ModuleTestBase {
         tb.createDirectories(classes);
 
         record TestCase(Path[] files, String... expectedLog){}
+        String nameSeparator = FileSystems.getDefault().getSeparator();
 
         TestCase[] testCases = new TestCase[] {
             new TestCase(new Path[] {m.resolve("module-info.java")},
@@ -1133,7 +1135,9 @@ public class EdgeCases extends ModuleTestBase {
                             }
                             private void record(TaskEvent e, String phase) {
                                 JavaFileObject source = e.getSourceFile();
-                                String sourceName = source != null ? source.getName() : "<none>";
+                                String sourceName = source != null ? source.getName()
+                                                                           .replace(nameSeparator, "/")
+                                                                   : "<none>";
                                 log.add(e.getKind() + ":" + phase + ":" + sourceName);
                             }
                         });


### PR DESCRIPTION
`JavaFileObject.getName()` uses platform-specific name separators in the path. The test needs to normalize name separators before comparing them with expected output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298463](https://bugs.openjdk.org/browse/JDK-8298463): tools/javac/modules/EdgeCases.java fails on Windows after JDK-8297988


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jdk20 pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/12.diff">https://git.openjdk.org/jdk20/pull/12.diff</a>

</details>
