### PR TITLE
8298084: Memory leak in Method::build_profiling_method_data

### DIFF
--- a/src/hotspot/share/memory/metadataFactory.hpp
+++ b/src/hotspot/share/memory/metadataFactory.hpp
@@ -62,7 +62,7 @@ class MetadataFactory : AllStatic {
 
   // Deallocation method for metadata
   template <class T>
-  static void free_metadata(ClassLoaderData* loader_data, T md) {
+  static void free_metadata(ClassLoaderData* loader_data, T* md) {
     if (md != NULL) {
       assert(loader_data != NULL, "shouldn't pass null");
       int size = md->size();
@@ -75,7 +75,7 @@ class MetadataFactory : AllStatic {
       // destructors and/or cleanup using deallocate_contents.
       // T is a potentially const or volatile qualified pointer. Remove the pointer and any const
       // or volatile so we can call the destructor of the type T points to.
-      using U = std::remove_cv_t<std::remove_pointer_t<T>>;
+      using U = std::remove_cv_t<T>;
       md->~U();
       loader_data->metaspace_non_null()->deallocate((MetaWord*)md, size, md->is_klass());
     }

--- a/src/hotspot/share/memory/metadataFactory.hpp
+++ b/src/hotspot/share/memory/metadataFactory.hpp
@@ -73,7 +73,7 @@ class MetadataFactory : AllStatic {
       // Call the destructor. This is currently used for MethodData which has a member
       // that needs to be destructed to release resources. Most Metadata derived classes have noop
       // destructors and/or cleanup using deallocate_contents.
-      // T is a potentially const or volatile qualified pointer. Remove the pointer and any const
+      // T is a potentially const or volatile qualified pointer. Remove any const
       // or volatile so we can call the destructor of the type T points to.
       using U = std::remove_cv_t<T>;
       md->~U();

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -598,7 +598,7 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
   // Can't release the constant pool here because the constant pool can be
   // deallocated separately from the InstanceKlass for default methods and
   // redefine classes.
-  release_C_heap_structures(/* release_constant_pool */ false);
+  release_C_heap_structures(/* release_sub_metadata */ false);
 
   deallocate_methods(loader_data, methods());
   set_methods(NULL);
@@ -2665,12 +2665,14 @@ static void method_release_C_heap_structures(Method* m) {
 }
 
 // Called also by InstanceKlass::deallocate_contents, with false for release_constant_pool.
-void InstanceKlass::release_C_heap_structures(bool release_constant_pool) {
+void InstanceKlass::release_C_heap_structures(bool release_sub_metadata) {
   // Clean up C heap
   Klass::release_C_heap_structures();
 
   // Deallocate and call destructors for MDO mutexes
-  methods_do(method_release_C_heap_structures);
+  if (release_sub_metadata) {
+    methods_do(method_release_C_heap_structures);
+  }
 
   // Destroy the init_monitor
   delete _init_monitor;
@@ -2710,7 +2712,7 @@ void InstanceKlass::release_C_heap_structures(bool release_constant_pool) {
 
   FREE_C_HEAP_ARRAY(char, _source_debug_extension);
 
-  if (release_constant_pool) {
+  if (release_sub_metadata) {
     constants()->release_C_heap_structures();
   }
 }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2664,9 +2664,7 @@ static void method_release_C_heap_structures(Method* m) {
   m->release_C_heap_structures();
 }
 
-// Called also by InstanceKlass::deallocate_contents, with false for releasing C heap
-// data pointed to metadata that this InstanceKlass points to (the subordinate metadata
-// releases its own C heap structures).
+// Called also by InstanceKlass::deallocate_contents, with false for release_sub_metadata.
 void InstanceKlass::release_C_heap_structures(bool release_sub_metadata) {
   // Clean up C heap
   Klass::release_C_heap_structures();

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -595,9 +595,9 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
 
   // Release C heap allocated data that this points to, which includes
   // reference counting symbol names.
-  // Can't release the constant pool here because the constant pool can be
-  // deallocated separately from the InstanceKlass for default methods and
-  // redefine classes.
+  // Can't release the constant pool or MethodData C heap data here because the constant
+  // pool can be deallocated separately from the InstanceKlass for default methods and
+  // redefine classes.  MethodData can also be released separately.
   release_C_heap_structures(/* release_sub_metadata */ false);
 
   deallocate_methods(loader_data, methods());
@@ -2664,7 +2664,9 @@ static void method_release_C_heap_structures(Method* m) {
   m->release_C_heap_structures();
 }
 
-// Called also by InstanceKlass::deallocate_contents, with false for release_constant_pool.
+// Called also by InstanceKlass::deallocate_contents, with false for releasing C heap
+// data pointed to metadata that this InstanceKlass points to (the subordinate metadata
+// releases its own C heap structures).
 void InstanceKlass::release_C_heap_structures(bool release_sub_metadata) {
   // Clean up C heap
   Klass::release_C_heap_structures();

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1012,7 +1012,7 @@ public:
   // callbacks for actions during class unloading
   static void unload_class(InstanceKlass* ik);
 
-  virtual void release_C_heap_structures(bool release_constant_pool = true);
+  virtual void release_C_heap_structures(bool release_sub_metadata = true);
 
   // Naming
   const char* signature_name() const;

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -141,10 +141,9 @@ void Method::deallocate_contents(ClassLoaderData* loader_data) {
 
 void Method::release_C_heap_structures() {
   if (method_data()) {
-#if INCLUDE_JVMCI
-    FailedSpeculation::free_failed_speculations(method_data()->get_failed_speculations_address());
-#endif
-    // Destroy MethodData
+    method_data()->release_C_heap_structures();
+
+    // Destroy MethodData embedded lock
     method_data()->~MethodData();
   }
 }

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1821,3 +1821,13 @@ void MethodData::clean_weak_method_links() {
   clean_extra_data(&cl);
   verify_extra_data_clean(&cl);
 }
+
+void MethodData::deallocate_contents(ClassLoaderData* loader_data) {
+  release_C_heap_structures();
+}
+
+void MethodData::release_C_heap_structures() {
+#if INCLUDE_JVMCI
+  FailedSpeculation::free_failed_speculations(get_failed_speculations_address());
+#endif
+}

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -2449,8 +2449,9 @@ public:
   virtual void metaspace_pointers_do(MetaspaceClosure* iter);
   virtual MetaspaceObj::Type type() const { return MethodDataType; }
 
-  // Deallocation support - no metaspace pointer fields to deallocate
-  void deallocate_contents(ClassLoaderData* loader_data) {}
+  // Deallocation support
+  void deallocate_contents(ClassLoaderData* loader_data);
+  void release_C_heap_structures();
 
   // GC support
   void set_size(int object_size_in_bytes) { _size = object_size_in_bytes; }


### PR DESCRIPTION
This change fixes the MethodData leak by calling the destructor in both the release_C_heap_structures conditionally and by calling the MethodData destructor in the MetadataFactory::free_metadata method.
Thanks to @jcking for working on the patch and discussion.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298084](https://bugs.openjdk.org/browse/JDK-8298084): Memory leak in Method::build_profiling_method_data


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [e195cd85](https://git.openjdk.org/jdk20/pull/13/files/e195cd854e801ec4fd0b7fc5723e4296753d90be)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [11fcdba0](https://git.openjdk.org/jdk20/pull/13/files/11fcdba0d70e4459fbecd88dd519d4acf73bce30)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Justin King](https://openjdk.org/census#jcking) (@jcking - Author)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Contributors
 * Justin King `<jcking@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jdk20 pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/13.diff">https://git.openjdk.org/jdk20/pull/13.diff</a>

</details>
