### PR TITLE
8297288: Example code in Scanner class

### DIFF
--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -55,7 +55,8 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * {@snippet :
  *     var con = System.console();
  *     if (con != null) {
- *         Scanner sc = new Scanner(con.reader()); // @link substring="reader()" target="java.io.Console#reader()"
+ *         // @link substring="reader()" target="java.io.Console#reader()" :
+ *         Scanner sc = new Scanner(con.reader());
  *         int i = sc.nextInt();
  *     }
  * }

--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,24 +51,27 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * various {@code next} methods.
  *
  * <p>For example, this code allows a user to read a number from
- * {@code System.in}:
- * <blockquote><pre>{@code
- *     Scanner sc = new Scanner(System.in);
- *     int i = sc.nextInt();
- * }</pre></blockquote>
+ * the console.
+ * {@snippet :
+ *     var con = System.console();
+ *     if (con != null) {
+ *         Scanner sc = new Scanner(con.reader()); // @link substring="reader()" target="java.io.Console#reader()"
+ *         int i = sc.nextInt();
+ *     }
+ * }
  *
  * <p>As another example, this code allows {@code long} types to be
  * assigned from entries in a file {@code myNumbers}:
- * <blockquote><pre>{@code
+ * {@snippet :
  *      Scanner sc = new Scanner(new File("myNumbers"));
  *      while (sc.hasNextLong()) {
  *          long aLong = sc.nextLong();
  *      }
- * }</pre></blockquote>
+ * }
  *
  * <p>The scanner can also use delimiters other than whitespace. This
  * example reads several items in from a string:
- * <blockquote><pre>{@code
+ * {@snippet :
  *     String input = "1 fish 2 fish red fish blue fish";
  *     Scanner s = new Scanner(input).useDelimiter("\\s*fish\\s*");
  *     System.out.println(s.nextInt());
@@ -76,7 +79,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *     System.out.println(s.next());
  *     System.out.println(s.next());
  *     s.close();
- * }</pre></blockquote>
+ * }
  * <p>
  * prints the following output:
  * <blockquote><pre>{@code
@@ -88,7 +91,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <p>The same output can be generated with this code, which uses a regular
  * expression to parse all four tokens at once:
- * <blockquote><pre>{@code
+ * {@snippet :
  *     String input = "1 fish 2 fish red fish blue fish";
  *     Scanner s = new Scanner(input);
  *     s.findInLine("(\\d+) fish (\\d+) fish (\\w+) fish (\\w+)");
@@ -96,7 +99,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *     for (int i=1; i<=result.groupCount(); i++)
  *         System.out.println(result.group(i));
  *     s.close();
- * }</pre></blockquote>
+ * }
  *
  * <p>The <a id="default-delimiter">default whitespace delimiter</a> used
  * by a scanner is as recognized by {@link Character#isWhitespace(char)


### PR DESCRIPTION
The example in `Scanner` directly uses `System.in` which may cause unwanted behavior when the default charset and the console charset differ. Using `Console.reader()` is more appropriate. Also changed examples into snippets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297288](https://bugs.openjdk.org/browse/JDK-8297288): Example code in Scanner class


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [ce1df2fd](https://git.openjdk.org/jdk20/pull/14/files/ce1df2fd12a3eec3e4de83aafc8b21fa71babe1c)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [ce1df2fd](https://git.openjdk.org/jdk20/pull/14/files/ce1df2fd12a3eec3e4de83aafc8b21fa71babe1c)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jdk20 pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/14.diff">https://git.openjdk.org/jdk20/pull/14.diff</a>

</details>
