### PR TITLE
8298527: Cygwin's uname -m returns different string than before

### DIFF
--- a/make/autoconf/build-aux/autoconf-config.guess
+++ b/make/autoconf/build-aux/autoconf-config.guess
@@ -866,7 +866,8 @@ EOF
     i*:UWIN*:*)
 	echo ${UNAME_MACHINE}-pc-uwin
 	exit ;;
-    amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:* | .x86_64:CYGWIN*:*:*)
+    #amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:* | .x86_64:CYGWIN*:*:*)
+    amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
 	echo x86_64-unknown-cygwin
 	exit ;;
     p*:CYGWIN*:*)

--- a/make/autoconf/build-aux/autoconf-config.guess
+++ b/make/autoconf/build-aux/autoconf-config.guess
@@ -866,7 +866,6 @@ EOF
     i*:UWIN*:*)
 	echo ${UNAME_MACHINE}-pc-uwin
 	exit ;;
-    #amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:* | .x86_64:CYGWIN*:*:*)
     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
 	echo x86_64-unknown-cygwin
 	exit ;;

--- a/make/autoconf/build-aux/autoconf-config.guess
+++ b/make/autoconf/build-aux/autoconf-config.guess
@@ -866,7 +866,7 @@ EOF
     i*:UWIN*:*)
 	echo ${UNAME_MACHINE}-pc-uwin
 	exit ;;
-    amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+    amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:* | .x86_64:CYGWIN*:*:*)
 	echo x86_64-unknown-cygwin
 	exit ;;
     p*:CYGWIN*:*)

--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -91,6 +91,16 @@ if [ "x$OUT" = x ]; then
   fi
 fi
 
+# Test and fix cygwin machine arch .x86_64
+# TODO: should be handled by autoconf-config.guess.
+if [ "x$OUT" = x ]; then
+  if [ `uname -m` = ".x86_64" ]; then
+    if [[ `uname -s` = CYGWIN* ]]; then
+      OUT=x86_64-unknown-cygwin
+    fi
+  fi
+fi
+
 # Test and fix little endian MIPS.
 if [ "x$OUT" = x ]; then
   if [ `uname -s` = Linux ]; then

--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -29,10 +29,7 @@
 # and fix the broken property, if needed.
 
 DIR=`dirname $0`
-TMPFILE=`mktemp`
-OUT=`. $DIR/autoconf-config.guess 2> "$TMPFILE"`
-ERR=`cat "$TMPFILE"`
-rm "$TMPFILE"
+OUT=`. $DIR/autoconf-config.guess 2> /dev/null`
 
 # Handle some cases that autoconf-config.guess is not capable of
 if [ "x$OUT" = x ]; then
@@ -60,7 +57,8 @@ if [ "x$OUT" = x ]; then
   fi
 
   if [ "x$OUT" = x ]; then
-    echo $ERR >&2
+    # Run autoconf-config.guess again to get the error message.
+    . $DIR/autoconf-config.guess > /dev/null
   else
     printf "guessed by custom config.guess... " >&2
   fi

--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -29,7 +29,42 @@
 # and fix the broken property, if needed.
 
 DIR=`dirname $0`
-OUT=`. $DIR/autoconf-config.guess`
+TMPFILE=`mktemp`
+OUT=`. $DIR/autoconf-config.guess 2> "$TMPFILE"`
+ERR=`cat "$TMPFILE"`
+rm "$TMPFILE"
+
+# Handle some cases that autoconf-config.guess is not capable of
+if [ "x$OUT" = x ]; then
+  if [ `uname -s` = Linux ]; then
+    # Test and fix little endian MIPS.
+    if [ `uname -m` = mipsel ]; then
+      OUT=mipsel-unknown-linux-gnu
+    elif [ `uname -m` = mips64el ]; then
+      OUT=mips64el-unknown-linux-gnu
+    # Test and fix little endian PowerPC64.
+    elif [ `uname -m` = ppc64le ]; then
+      OUT=powerpc64le-unknown-linux-gnu
+    # Test and fix LoongArch64.
+    elif [ `uname -m` = loongarch64 ]; then
+      OUT=loongarch64-unknown-linux-gnu
+    # Test and fix RISC-V.
+    elif [ `uname -m` = riscv64 ]; then
+      OUT=riscv64-unknown-linux-gnu
+    fi
+  # Test and fix cygwin machine arch .x86_64
+  elif [[ `uname -s` = CYGWIN* ]]; then
+    if [ `uname -m` = ".x86_64" ]; then
+      OUT=x86_64-unknown-cygwin
+    fi
+  fi
+
+  if [ "x$OUT" = x ]; then
+    echo $ERR >&2
+  else
+    printf "guessed by custom config.guess... " >&2
+  fi
+fi
 
 # Detect C library.
 # Use '-gnu'  suffix on systems that use glibc.
@@ -79,55 +114,6 @@ if test $? = 0; then
     fi
   fi
   OUT=powerpc$KERNEL_BITMODE`echo $OUT | sed -e 's/[^-]*//'`
-fi
-
-# Test and fix little endian PowerPC64.
-# TODO: should be handled by autoconf-config.guess.
-if [ "x$OUT" = x ]; then
-  if [ `uname -m` = ppc64le ]; then
-    if [ `uname -s` = Linux ]; then
-      OUT=powerpc64le-unknown-linux-gnu
-    fi
-  fi
-fi
-
-# Test and fix cygwin machine arch .x86_64
-# TODO: should be handled by autoconf-config.guess.
-if [ "x$OUT" = x ]; then
-  if [ `uname -m` = ".x86_64" ]; then
-    if [[ `uname -s` = CYGWIN* ]]; then
-      OUT=x86_64-unknown-cygwin
-    fi
-  fi
-fi
-
-# Test and fix little endian MIPS.
-if [ "x$OUT" = x ]; then
-  if [ `uname -s` = Linux ]; then
-    if [ `uname -m` = mipsel ]; then
-      OUT=mipsel-unknown-linux-gnu
-    elif [ `uname -m` = mips64el ]; then
-      OUT=mips64el-unknown-linux-gnu
-    fi
-  fi
-fi
-
-# Test and fix LoongArch64.
-if [ "x$OUT" = x ]; then
-  if [ `uname -s` = Linux ]; then
-    if [ `uname -m` = loongarch64 ]; then
-      OUT=loongarch64-unknown-linux-gnu
-    fi
-  fi
-fi
-
-# Test and fix RISC-V.
-if [ "x$OUT" = x ]; then
-  if [ `uname -s` = Linux ]; then
-    if [ `uname -m` = riscv64 ]; then
-      OUT=riscv64-unknown-linux-gnu
-    fi
-  fi
 fi
 
 # Test and fix cpu on macos-aarch64, uname -p reports arm, buildsys expects aarch64


### PR DESCRIPTION
`uname -m` returns `.x86_64` after the latest upgread, instead of `x86_64`. Not sure why.

However, we can handle this in autoconf-config.guess, to unbreak the build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298527](https://bugs.openjdk.org/browse/JDK-8298527): Cygwin's uname -m returns different string than before


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/jdk20 pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/15.diff">https://git.openjdk.org/jdk20/pull/15.diff</a>

</details>
