### PR TITLE
8298296: gc/TestFullGCCount.java fails with "System.gc collections miscounted."

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -80,7 +80,6 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293,8298073 macosx-x64,macosx-aarch64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
-gc/TestFullGCCount.java 8298296 linux-x64
 
 #############################################################################
 

--- a/test/hotspot/jtreg/gc/TestFullGCCount.java
+++ b/test/hotspot/jtreg/gc/TestFullGCCount.java
@@ -29,6 +29,8 @@ package gc;
  * @summary JMM GC counters overcount in some cases
  * @comment Shenandoah has "ExplicitGCInvokesConcurrent" on by default
  * @requires !(vm.gc == "Shenandoah" & vm.opt.ExplicitGCInvokesConcurrent != false)
+ * @comment G1 has separate counters for STW Full GC and concurrent GC.
+ * @requires !(vm.gc == "G1" & vm.opt.ExplicitGCInvokesConcurrent)
  * @requires vm.gc != "Z"
  * @modules java.management
  * @run main/othervm -Xlog:gc gc.TestFullGCCount


### PR DESCRIPTION
Please review this change to the gc/TestFullGCCount.java test to account for
the changes in JDK-8297247.  The test was not updated by that change to
account for the new separation by G1 of STW full gc counts from concurrent
cycle counts in the GarbageCollectorMXBean.

To address this, the test has been changed to not be run if using G1 and
-XX:+ExplicitGCInvokesConcurrent.

Testing:
Verified the unmodified test fails when using G1 and +ExplicitGCInvokesConcurrent.
After updating the test, ran it with G1 selected and both with and without
ExplicitGCInvokesConcurrent.  With now suppresses the test, without runs it
successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298296](https://bugs.openjdk.org/browse/JDK-8298296): gc/TestFullGCCount.java fails with "System.gc collections miscounted."


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jdk20 pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/16.diff">https://git.openjdk.org/jdk20/pull/16.diff</a>

</details>
