### PR TITLE
8298083: The "CheckBox/RadioButton[Enabled/Disabled].textForeground" stoped working

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,18 +286,6 @@ class GTKStyle extends SynthStyle implements GTKConstants {
                 }
             }
         }
-
-        if ((c instanceof JCheckBox) && (state & SynthConstants.DISABLED) != 0) {
-            if (UIManager.getColor("CheckBox.disabledText") != null) {
-                return UIManager.getColor("CheckBox.disabledText");
-            }
-        } else if ((c instanceof JRadioButton) &&
-                (state & SynthConstants.DISABLED) != 0) {
-            if (UIManager.getColor("RadioButton.disabledText") != null) {
-                return UIManager.getColor("RadioButton.disabledText");
-            }
-        }
-
         return getColorForState(context, type);
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthStyle.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -779,14 +779,6 @@ public abstract class SynthStyle {
                             (type == ColorType.FOREGROUND ||
                              type == ColorType.TEXT_FOREGROUND)) {
                 return getColorForState(context, type);
-            } else if (c instanceof JCheckBox) {
-                if (UIManager.getColor("CheckBox.disabledText") != null) {
-                    return UIManager.getColor("CheckBox.disabledText");
-                }
-            } else if (c instanceof JRadioButton) {
-                if (UIManager.getColor("RadioButton.disabledText") != null) {
-                    return UIManager.getColor("RadioButton.disabledText");
-                }
             }
         }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -664,6 +664,7 @@ javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
+javax/swing/JRadioButton/4314194/bug4314194.java 8298153 linux-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [5540a8c5](https://github.com/openjdk/jdk/commit/5540a8c5b7160ab5c67bb84631e3de54fa5aeceb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 8 Dec 2022 and was reviewed by Prasanta Sadhukhan.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298083](https://bugs.openjdk.org/browse/JDK-8298083): The "CheckBox/RadioButton[Enabled/Disabled].textForeground" stoped working


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jdk20 pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/17.diff">https://git.openjdk.org/jdk20/pull/17.diff</a>

</details>
