### PR TITLE
8295857: Clarify that cleanup code can be skipped when the JVM terminates (e.g. when calling halt())

### DIFF
--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -89,10 +89,14 @@ import jdk.internal.reflect.Reflection;
  * shutdown sequence.
  *
  * <p>When the JVM terminates, all threads are immediately prevented from executing any further
- * Java code. This includes shutdown hooks as well as daemon and non-daemon threads. The
- * threads' current methods do not complete normally or abruptly; no {@code finally} clause
- * of any method is executed, nor is any {@linkplain Thread.UncaughtExceptionHandler
- * uncaught exception handler}.
+ * Java code. This includes shutdown hooks as well as daemon and non-daemon threads.
+ * This means, for example, that:
+ * <ul>
+ * <li>threads' current methods do not complete normally or abruptly;</li>
+ * <li>{@code finally} clauses are not executed;</li>
+ * <li>{@linkplain Thread.UncaughtExceptionHandler uncaught exception handlers} are not run; and</li>
+ * <li>resources opened with try-with-resources are not {@linkplain AutoCloseable closed};</li>
+ * </ul>
  *
  * @implNote
  * Native code typically uses the
@@ -278,7 +282,8 @@ public class Runtime {
      * @apiNote
      * This method should be used with extreme caution. Using it may circumvent or disrupt
      * any cleanup actions intended to be performed by shutdown hooks, possibly leading to
-     * data corruption.
+     * data corruption. See the <a href="#termination">termination</a> section above
+     * for other possible consequences of halting the Java Virtual Machine.
      *
      * @param  status
      *         Termination status. By convention, a nonzero status code


### PR DESCRIPTION
Backport [8295857](https://bugs.openjdk.org/browse/JDK-8295857) to jdk20

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295857](https://bugs.openjdk.org/browse/JDK-8295857): Clarify that cleanup code can be skipped when the JVM terminates (e.g. when calling halt())


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/jdk20 pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/19.diff">https://git.openjdk.org/jdk20/pull/19.diff</a>

</details>
