### PR TITLE
8298488: [macos13] tools/jpackage tests failing with "Exit code: 137" on macOS

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
@@ -401,7 +401,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
                         ENTITLEMENTS.fetchFrom(params));
             }
             restoreKeychainList(params);
-        } else if (Platform.isArmMac()) {
+        } else if (Platform.isMac()) {
             signAppBundle(params, root, "-", null, null);
         } else {
             // Calling signAppBundle() without signingIdentity will result in

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -180,10 +180,6 @@ final public class TKit {
         return (OS.contains("mac"));
     }
 
-    public static boolean isArmMac() {
-        return (isOSX() && "aarch64".equals(System.getProperty("os.arch")));
-    }
-
     public static boolean isLinux() {
         return ((OS.contains("nix") || OS.contains("nux")));
     }

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -101,7 +101,7 @@ public class AppContentTest {
             })
             // On macOS aarch64 we always signing app image and signing will fail, since
             // test produces invalid app bundle.
-            .setExpectedExitCode(testPathArgs.contains(TEST_BAD) || TKit.isArmMac() ? 1 : 0)
+            .setExpectedExitCode(testPathArgs.contains(TEST_BAD) || TKit.isOSX() ? 1 : 0)
             .run();
         }
 }


### PR DESCRIPTION
This issue is similar to JDK-8277493. Looks like macOS 13 cannot execute unsigned code and code should be at least ad hoc signed. Same as for macOS aarch64. Fixed by enabling ad hoc signing for macOS platform for both x64 and aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298488](https://bugs.openjdk.org/browse/JDK-8298488): [macos13] tools/jpackage tests failing with "Exit code: 137" on macOS


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/jdk20 pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/20.diff">https://git.openjdk.org/jdk20/pull/20.diff</a>

</details>
