### PR TITLE
8298050: Add links to graph output for javadoc

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
+++ b/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.System.lineSeparator;
 import static java.nio.file.StandardOpenOption.*;
+import static java.util.stream.Collectors.joining;
 import static jdk.javadoc.doclet.Taglet.Location.TYPE;
 
 /**
@@ -159,13 +160,17 @@ public final class SealedGraph implements Taglet {
 
             private static final String LABEL = "label";
             private static final String TOOLTIP = "tooltip";
+            private static final String LINK = "href";
             private static final String STYLE = "style";
+
+            private final TypeElement rootNode;
 
             private final StringBuilder builder;
 
             private final Map<String, Map<String, String>> nodeStyleMap;
 
             public State(TypeElement rootNode) {
+                this.rootNode = rootNode;
                 nodeStyleMap = new LinkedHashMap<>();
                 builder = new StringBuilder()
                         .append("digraph G {")
@@ -188,10 +193,24 @@ public final class SealedGraph implements Taglet {
                 var styles = nodeStyleMap.computeIfAbsent(id(node), n -> new LinkedHashMap<>());
                 styles.put(LABEL, node.getSimpleName().toString());
                 styles.put(TOOLTIP, node.getQualifiedName().toString());
+                styles.put(LINK, relativeLink(rootNode, node));
                 if (!(node.getModifiers().contains(Modifier.SEALED) || node.getModifiers().contains(Modifier.FINAL))) {
                     // This indicates that the hierarchy is not closed
                     styles.put(STYLE, "dashed");
                 }
+            }
+
+            // A permitted class must be in the same package or in the same module.
+            // This implies the module is always the same.
+            private static String relativeLink(TypeElement rootNode, TypeElement node) {
+                var backNavigator = rootNode.getQualifiedName().toString().chars()
+                        .filter(c -> c == '.')
+                        .mapToObj(c -> "../")
+                        .collect(joining());
+                var forwardNavigator = node.getQualifiedName().toString()
+                        .replace(".", "/");
+
+                return backNavigator + forwardNavigator + ".html";
             }
 
             public void addEdge(TypeElement node, TypeElement subNode) {
@@ -209,8 +228,8 @@ public final class SealedGraph implements Taglet {
                             .append('"').append(nodeName).append("\" ")
                             .append(styles.entrySet().stream()
                                     .map(e -> e.getKey() + "=\"" + e.getValue() + "\"")
-                                    .collect(Collectors.joining(" ", "[", "]")))
-                            .append(System.lineSeparator());
+                                    .collect(joining(" ", "[", "]")))
+                            .append(lineSeparator());
                 });
                 builder.append("}");
                 return builder.toString();


### PR DESCRIPTION
This PR proposes adding hyperlinks to the sealed graphic layout making navigation much simpler via the image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298050](https://bugs.openjdk.org/browse/JDK-8298050): Add links to graph output for javadoc


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [6521807f](https://git.openjdk.org/jdk20/pull/23/files/6521807faede2e0ec5fe514f73fa908501570412)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/jdk20 pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/23.diff">https://git.openjdk.org/jdk20/pull/23.diff</a>

</details>
