### PR TITLE
8298520: C2: assert(found_opaque == res) failed: wrong pattern

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2547,7 +2547,8 @@ SafePointNode* CountedLoopNode::outer_safepoint() const {
 
 Node* CountedLoopNode::skip_predicates_from_entry(Node* ctrl) {
     while (ctrl != NULL && ctrl->is_Proj() && ctrl->in(0) != NULL && ctrl->in(0)->is_If() &&
-            (ctrl->in(0)->as_If()->proj_out_or_null(1-ctrl->as_Proj()->_con) == NULL ||
+           !is_zero_trip_guard_if(ctrl->in(0)->as_If()) &&
+           (ctrl->in(0)->as_If()->proj_out_or_null(1-ctrl->as_Proj()->_con) == NULL ||
              (ctrl->in(0)->as_If()->proj_out(1-ctrl->as_Proj()->_con)->outcnt() == 1 &&
               ctrl->in(0)->as_If()->proj_out(1-ctrl->as_Proj()->_con)->unique_out()->Opcode() == Op_Halt))) {
       ctrl = ctrl->in(0)->in(0);
@@ -2555,6 +2556,22 @@ Node* CountedLoopNode::skip_predicates_from_entry(Node* ctrl) {
 
     return ctrl;
   }
+
+bool CountedLoopNode::is_zero_trip_guard_if(const IfNode* iff) {
+  if (iff->in(1) == NULL || !iff->in(1)->is_Bool()) {
+    return false;
+  }
+  if (iff->in(1)->in(1) == NULL || iff->in(1)->in(1)->Opcode() != Op_CmpI) {
+    return false;
+  }
+  if (iff->in(1)->in(1)->in(1) != NULL && iff->in(1)->in(1)->in(1)->Opcode() == Op_OpaqueZeroTripGuard) {
+    return true;
+  }
+  if (iff->in(1)->in(1)->in(2) != NULL && iff->in(1)->in(1)->in(2)->Opcode() == Op_OpaqueZeroTripGuard) {
+    return true;
+  }
+  return false;
+}
 
 Node* CountedLoopNode::skip_predicates() {
   Node* ctrl = in(LoopNode::EntryControl);
@@ -5459,7 +5476,7 @@ Node* CountedLoopNode::is_canonical_loop_entry() {
     return NULL;
   }
   Node* iffm = ctrl->in(0);
-  if (iffm == NULL || !iffm->is_If()) {
+  if (iffm == NULL || iffm->Opcode() != Op_If) {
     return NULL;
   }
   Node* bolzm = iffm->in(1);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -355,6 +355,8 @@ public:
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;
 #endif
+
+  static bool is_zero_trip_guard_if(const IfNode* iff);
 };
 
 class LongCountedLoopNode : public BaseCountedLoopNode {


### PR DESCRIPTION
The assert fires because CountedLoopNode::is_canonical_loop_entry()
finds an Opaque1 where it expects an OpaqueZeroTripGuard. That Opaque1
guards the CountedLoopEnd of the pre loop: is_canonical_loop_entry()
should have stopped at the zero trip guard but walked past it. The
reason for that is the call for skip_predicates(): when
CountedLoopNode::skip_predicates_from_entry() encounters an If node
that has lost a projection, it assumes it's a predicate and moves to
the next one. In this case, the zero trip guard only has one
projection (the one that connects it through predicates to the loop
head), because igvn is in the process of updating a dead part of the
graph.

To fix this, I propose that:

1- CountedLoopNode::is_canonical_loop_entry() fails when after
predicates it's at a CountedLoopEnd.

2- CountedLoopNode::skip_predicates_from_entry() stops at a zero trip
guard (identified by a condition that uses a OpaqueZeroTripGuard)

Either 1- or 2- are good enough to fix this particular graph but I
propose doing both as making this logic more robust feels safer.

I don't provide a test case as this seems to only happen when igvn
processes a dying subgraph in a very specific order.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298520](https://bugs.openjdk.org/browse/JDK-8298520): C2: assert(found_opaque == res) failed: wrong pattern


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jdk20 pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/24.diff">https://git.openjdk.org/jdk20/pull/24.diff</a>

</details>
