### PR TITLE
JDK-8297305: Clarify that javax.lang.model.util.Elements.overrides is irreflexive

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -622,6 +622,8 @@ public interface Elements {
      * overrides another method.
      * When a non-abstract method overrides an abstract one, the
      * former is also said to <i>implement</i> the latter.
+     * As implied by JLS {@jls 8.4.8.1}, a method does <em>not</em>
+     * override itself. The overrides relation is <i>irreflexive</i>.
      *
      * <p> In the simplest and most typical usage, the value of the
      * {@code type} parameter will simply be the class or interface


### PR DESCRIPTION
Please review this spec clarification and its companion CSR https://bugs.openjdk.org/browse/JDK-8298698

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8297305](https://bugs.openjdk.org/browse/JDK-8297305): Clarify that javax.lang.model.util.Elements.overrides is irreflexive
 * [JDK-8298698](https://bugs.openjdk.org/browse/JDK-8298698): Clarify that javax.lang.model.util.Elements.overrides is irreflexive (**CSR**)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/jdk20 pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/27.diff">https://git.openjdk.org/jdk20/pull/27.diff</a>

</details>
