### PR TITLE
JDK-8298700: Typo in DocTree comment

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
@@ -227,7 +227,7 @@ public interface DocTree {
         SPEC("spec"),
 
         /**
-         * Used for instances of {@link EndElementTree}
+         * Used for instances of {@link StartElementTree}
          * representing the start of an HTML element.
          */
         START_ELEMENT,


### PR DESCRIPTION
Please review a trivial fix to a long-standing copy-paste typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298700](https://bugs.openjdk.org/browse/JDK-8298700): Typo in DocTree comment


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/jdk20 pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/28.diff">https://git.openjdk.org/jdk20/pull/28.diff</a>

</details>
