### PR TITLE
JDK-8298277: Replace "session" with "scope" for FFM access

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -79,7 +79,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
     }
 
     @Override
-    abstract HeapMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope session);
+    abstract HeapMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope scope);
 
     @Override
     ByteBuffer makeByteBuffer() {
@@ -99,7 +99,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfByte dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfByte dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfByte(this.offset + offset, base, size, readOnly);
         }
 
@@ -132,7 +132,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfChar dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfChar dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfChar(this.offset + offset, base, size, readOnly);
         }
 
@@ -165,7 +165,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfShort dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfShort dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfShort(this.offset + offset, base, size, readOnly);
         }
 
@@ -198,7 +198,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfInt dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfInt dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfInt(this.offset + offset, base, size, readOnly);
         }
 
@@ -231,7 +231,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfLong dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfLong dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfLong(this.offset + offset, base, size, readOnly);
         }
 
@@ -264,7 +264,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfFloat dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfFloat dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfFloat(this.offset + offset, base, size, readOnly);
         }
 
@@ -297,7 +297,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         }
 
         @Override
-        OfDouble dup(long offset, long size, boolean readOnly, SegmentScope session) {
+        OfDouble dup(long offset, long size, boolean readOnly, SegmentScope scope) {
             return new OfDouble(this.offset + offset, base, size, readOnly);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -43,20 +43,20 @@ public sealed class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
-    public MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, boolean readOnly, SegmentScope session) {
-        super(min, length, readOnly, session);
+    public MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, boolean readOnly, SegmentScope scope) {
+        super(min, length, readOnly, scope);
         this.unmapper = unmapper;
     }
 
     @Override
     ByteBuffer makeByteBuffer() {
         return NIO_ACCESS.newMappedByteBuffer(unmapper, min, (int)length, null,
-                session == MemorySessionImpl.GLOBAL ? null : this);
+                scope == MemorySessionImpl.GLOBAL ? null : this);
     }
 
     @Override
-    MappedMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope session) {
-        return new MappedMemorySegmentImpl(min + offset, unmapper, size, readOnly, session);
+    MappedMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope scope) {
+        return new MappedMemorySegmentImpl(min + offset, unmapper, size, readOnly, scope);
     }
 
     // mapped segment methods

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -175,9 +175,9 @@ public abstract sealed class MemorySessionImpl
         return owner;
     }
 
-    public static boolean sameOwnerThread(SegmentScope session1, SegmentScope session2) {
-        return ((MemorySessionImpl) session1).ownerThread() ==
-                ((MemorySessionImpl) session2).ownerThread();
+    public static boolean sameOwnerThread(SegmentScope scope1, SegmentScope scope2) {
+        return ((MemorySessionImpl) scope1).ownerThread() ==
+                ((MemorySessionImpl) scope2).ownerThread();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -52,8 +52,8 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     final long min;
 
     @ForceInline
-    NativeMemorySegmentImpl(long min, long length, boolean readOnly, SegmentScope session) {
-        super(length, readOnly, session);
+    NativeMemorySegmentImpl(long min, long length, boolean readOnly, SegmentScope scope) {
+        super(length, readOnly, scope);
         this.min = min;
     }
 
@@ -69,14 +69,14 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
 
     @ForceInline
     @Override
-    NativeMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope session) {
-        return new NativeMemorySegmentImpl(min + offset, size, readOnly, session);
+    NativeMemorySegmentImpl dup(long offset, long size, boolean readOnly, SegmentScope scope) {
+        return new NativeMemorySegmentImpl(min + offset, size, readOnly, scope);
     }
 
     @Override
     ByteBuffer makeByteBuffer() {
         return NIO_ACCESS.newDirectByteBuffer(min, (int) this.length, null,
-                session == MemorySessionImpl.GLOBAL ? null : this);
+                scope == MemorySessionImpl.GLOBAL ? null : this);
     }
 
     @Override
@@ -101,8 +101,8 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
 
     // factories
 
-    public static MemorySegment makeNativeSegment(long byteSize, long byteAlignment, SegmentScope session) {
-        MemorySessionImpl sessionImpl = (MemorySessionImpl) session;
+    public static MemorySegment makeNativeSegment(long byteSize, long byteAlignment, SegmentScope scope) {
+        MemorySessionImpl sessionImpl = (MemorySessionImpl) scope;
         sessionImpl.checkValidState();
         if (VM.isDirectMemoryPageAligned()) {
             byteAlignment = Math.max(byteAlignment, NIO_ACCESS.pageSize());
@@ -119,7 +119,7 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
         }
         long alignedBuf = Utils.alignUp(buf, byteAlignment);
         AbstractMemorySegmentImpl segment = new NativeMemorySegmentImpl(buf, alignedSize,
-                false, session);
+                false, scope);
         sessionImpl.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
             @Override
             public void cleanup() {
@@ -138,21 +138,21 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     // associated with MemorySegment::ofAddress.
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope session, Runnable action) {
-        MemorySessionImpl sessionImpl = (MemorySessionImpl) session;
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope scope, Runnable action) {
+        MemorySessionImpl sessionImpl = (MemorySessionImpl) scope;
         if (action == null) {
             sessionImpl.checkValidState();
         } else {
             sessionImpl.addCloseAction(action);
         }
-        return new NativeMemorySegmentImpl(min, byteSize, false, session);
+        return new NativeMemorySegmentImpl(min, byteSize, false, scope);
     }
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope session) {
-        MemorySessionImpl sessionImpl = (MemorySessionImpl) session;
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, SegmentScope scope) {
+        MemorySessionImpl sessionImpl = (MemorySessionImpl) scope;
         sessionImpl.checkValidState();
-        return new NativeMemorySegmentImpl(min, byteSize, false, session);
+        return new NativeMemorySegmentImpl(min, byteSize, false, scope);
     }
 
     @ForceInline

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -202,19 +202,19 @@ public interface Binding {
      */
     class Context implements AutoCloseable {
         private final SegmentAllocator allocator;
-        private final SegmentScope session;
+        private final SegmentScope scope;
 
-        private Context(SegmentAllocator allocator, SegmentScope session) {
+        private Context(SegmentAllocator allocator, SegmentScope scope) {
             this.allocator = allocator;
-            this.session = session;
+            this.scope = scope;
         }
 
         public SegmentAllocator allocator() {
             return allocator;
         }
 
-        public SegmentScope session() {
-            return session;
+        public SegmentScope scope() {
+            return scope;
         }
 
         @Override
@@ -242,7 +242,7 @@ public interface Binding {
         public static Context ofAllocator(SegmentAllocator allocator) {
             return new Context(allocator, null) {
                 @Override
-                public SegmentScope session() {
+                public SegmentScope scope() {
                     throw new UnsupportedOperationException();
                 }
             };
@@ -252,7 +252,7 @@ public interface Binding {
          * Create a binding context from given scope. The resulting context will throw when
          * the context's allocator is accessed.
          */
-        public static Context ofSession() {
+        public static Context ofScope() {
             Arena arena = Arena.openConfined();
             return new Context(null, arena.scope()) {
                 @Override
@@ -276,7 +276,7 @@ public interface Binding {
             }
 
             @Override
-            public SegmentScope session() {
+            public SegmentScope scope() {
                 throw new UnsupportedOperationException();
             }
 
@@ -678,10 +678,10 @@ public interface Binding {
 
     /**
      * BOX_ADDRESS()
-     * Pops a 'long' from the operand stack, converts it to a 'MemorySegment', with the given size and memory session
-     * (either the context session, or the global session), and pushes that onto the operand stack.
+     * Pops a 'long' from the operand stack, converts it to a 'MemorySegment', with the given size and memory scope
+     * (either the context scope, or the global scope), and pushes that onto the operand stack.
      */
-    record BoxAddress(long size, boolean needsSession) implements Binding {
+    record BoxAddress(long size, boolean needsScope) implements Binding {
 
         @Override
         public Tag tag() {
@@ -698,9 +698,9 @@ public interface Binding {
         @Override
         public void interpret(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc,
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
-            SegmentScope session = needsSession ?
-                    context.session() : SegmentScope.global();
-            stack.push(NativeMemorySegmentImpl.makeNativeSegmentUnchecked((long) stack.pop(), size, session));
+            SegmentScope scope = needsScope ?
+                    context.scope() : SegmentScope.global();
+            stack.push(NativeMemorySegmentImpl.makeNativeSegmentUnchecked((long) stack.pop(), size, scope));
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -80,9 +80,9 @@ public class BindingSpecializer {
 
     private static final String BINDING_CONTEXT_DESC = Binding.Context.class.descriptorString();
     private static final String OF_BOUNDED_ALLOCATOR_DESC = methodType(Binding.Context.class, long.class).descriptorString();
-    private static final String OF_SESSION_DESC = methodType(Binding.Context.class).descriptorString();
+    private static final String OF_SCOPE_DESC = methodType(Binding.Context.class).descriptorString();
     private static final String ALLOCATOR_DESC = methodType(SegmentAllocator.class).descriptorString();
-    private static final String SESSION_DESC = methodType(SegmentScope.class).descriptorString();
+    private static final String SCOPE_DESC = methodType(SegmentScope.class).descriptorString();
     private static final String SESSION_IMPL_DESC = methodType(MemorySessionImpl.class).descriptorString();
     private static final String CLOSE_DESC = VOID_DESC;
     private static final String UNBOX_SEGMENT_DESC = methodType(long.class, MemorySegment.class).descriptorString();
@@ -294,7 +294,7 @@ public class BindingSpecializer {
             emitConst(callingSequence.allocationSize());
             emitInvokeStatic(Binding.Context.class, "ofBoundedAllocator", OF_BOUNDED_ALLOCATOR_DESC);
         } else if (callingSequence.forUpcall() && needsSession()) {
-            emitInvokeStatic(Binding.Context.class, "ofSession", OF_SESSION_DESC);
+            emitInvokeStatic(Binding.Context.class, "ofScope", OF_SCOPE_DESC);
         } else {
             emitGetStatic(Binding.Context.class, "DUMMY", BINDING_CONTEXT_DESC);
         }
@@ -436,7 +436,7 @@ public class BindingSpecializer {
         return callingSequence.argumentBindings()
                 .filter(Binding.BoxAddress.class::isInstance)
                 .map(Binding.BoxAddress.class::cast)
-                .anyMatch(Binding.BoxAddress::needsSession);
+                .anyMatch(Binding.BoxAddress::needsScope);
     }
 
     private boolean shouldAcquire(int paramIndex) {
@@ -561,7 +561,7 @@ public class BindingSpecializer {
     private void emitLoadInternalSession() {
         assert contextIdx != -1;
         emitLoad(Object.class, contextIdx);
-        emitInvokeVirtual(Binding.Context.class, "session", SESSION_DESC);
+        emitInvokeVirtual(Binding.Context.class, "scope", SCOPE_DESC);
     }
 
     private void emitLoadInternalAllocator() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -288,21 +288,21 @@ public final class SharedUtils {
             throw new IllegalArgumentException("Symbol is NULL: " + symbol);
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope session) {
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope scope) {
         return switch (CABI.current()) {
-            case WIN_64 -> Windowsx64Linker.newVaList(actions, session);
-            case SYS_V -> SysVx64Linker.newVaList(actions, session);
-            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaList(actions, session);
-            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaList(actions, session);
+            case WIN_64 -> Windowsx64Linker.newVaList(actions, scope);
+            case SYS_V -> SysVx64Linker.newVaList(actions, scope);
+            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaList(actions, scope);
+            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaList(actions, scope);
         };
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
         return switch (CABI.current()) {
-            case WIN_64 -> Windowsx64Linker.newVaListOfAddress(address, session);
-            case SYS_V -> SysVx64Linker.newVaListOfAddress(address, session);
-            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaListOfAddress(address, session);
-            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaListOfAddress(address, session);
+            case WIN_64 -> Windowsx64Linker.newVaListOfAddress(address, scope);
+            case SYS_V -> SysVx64Linker.newVaListOfAddress(address, scope);
+            case LINUX_AARCH_64 -> LinuxAArch64Linker.newVaListOfAddress(address, scope);
+            case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaListOfAddress(address, scope);
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -61,7 +61,7 @@ public class UpcallLinker {
         }
     }
 
-    public static MemorySegment make(ABIDescriptor abi, MethodHandle target, CallingSequence callingSequence, SegmentScope session) {
+    public static MemorySegment make(ABIDescriptor abi, MethodHandle target, CallingSequence callingSequence, SegmentScope scope) {
         assert callingSequence.forUpcall();
         Binding.VMLoad[] argMoves = argMoveBindings(callingSequence);
         Binding.VMStore[] retMoves = retMoveBindings(callingSequence);
@@ -93,7 +93,7 @@ public class UpcallLinker {
         CallRegs conv = new CallRegs(args, rets);
         long entryPoint = makeUpcallStub(doBindings, abi, conv,
                 callingSequence.needsReturnBuffer(), callingSequence.returnBufferSize());
-        return UpcallStubs.makeUpcall(entryPoint, session);
+        return UpcallStubs.makeUpcall(entryPoint, scope);
     }
 
     private static void checkPrimitive(MethodType type) {
@@ -130,7 +130,7 @@ public class UpcallLinker {
     private static Object invokeInterpBindings(Object[] lowLevelArgs, InvocationData invData) throws Throwable {
         Binding.Context allocator = invData.callingSequence.allocationSize() != 0
                 ? Binding.Context.ofBoundedAllocator(invData.callingSequence.allocationSize())
-                : Binding.Context.ofSession();
+                : Binding.Context.ofScope();
         try (allocator) {
             /// Invoke interpreter, got array of high-level arguments back
             Object[] highLevelArgs = new Object[invData.callingSequence.calleeMethodType().parameterCount()];

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
@@ -50,13 +50,13 @@ public final class UpcallStubs {
         registerNatives();
     }
 
-    static MemorySegment makeUpcall(long entry, SegmentScope session) {
-        ((MemorySessionImpl) session).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+    static MemorySegment makeUpcall(long entry, SegmentScope scope) {
+        ((MemorySessionImpl) scope).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
             @Override
             public void cleanup() {
                 freeUpcallStub(entry);
             }
         });
-        return MemorySegment.ofAddress(entry, 0, session);
+        return MemorySegment.ofAddress(entry, 0, scope);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -65,14 +65,14 @@ public final class LinuxAArch64Linker extends AbstractLinker {
         return CallArranger.LINUX.arrangeUpcall(target, targetType, function, scope);
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope session) {
-        LinuxAArch64VaList.Builder builder = LinuxAArch64VaList.builder(session);
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope scope) {
+        LinuxAArch64VaList.Builder builder = LinuxAArch64VaList.builder(scope);
         actions.accept(builder);
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return LinuxAArch64VaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return LinuxAArch64VaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -65,14 +65,14 @@ public final class MacOsAArch64Linker extends AbstractLinker {
         return CallArranger.MACOS.arrangeUpcall(target, targetType, function, scope);
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope session) {
-        MacOsAArch64VaList.Builder builder = MacOsAArch64VaList.builder(session);
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SegmentScope scope) {
+        MacOsAArch64VaList.Builder builder = MacOsAArch64VaList.builder(scope);
         actions.accept(builder);
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return MacOsAArch64VaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return MacOsAArch64VaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -132,14 +132,14 @@ public class CallArranger {
         return handle;
     }
 
-    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
+    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope scope) {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
             target = SharedUtils.adaptUpcallForIMR(target, true /* drop return, since we don't have bindings for it */);
         }
 
-        return UpcallLinker.make(CSysV, target, bindings.callingSequence, session);
+        return UpcallLinker.make(CSysV, target, bindings.callingSequence, scope);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -68,8 +68,8 @@ public final class SysVx64Linker extends AbstractLinker {
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return SysVVaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return SysVVaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -131,14 +131,14 @@ public class CallArranger {
         return handle;
     }
 
-    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
+    public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope scope) {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
             target = SharedUtils.adaptUpcallForIMR(target, false /* need the return value as well */);
         }
 
-        return UpcallLinker.make(CWindows, target, bindings.callingSequence, session);
+        return UpcallLinker.make(CWindows, target, bindings.callingSequence, scope);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -149,12 +149,12 @@ public non-sealed class WinVaList implements VaList {
         }
     }
 
-    static WinVaList ofAddress(long address, SegmentScope session) {
-        return new WinVaList(MemorySegment.ofAddress(address, Long.MAX_VALUE, session));
+    static WinVaList ofAddress(long address, SegmentScope scope) {
+        return new WinVaList(MemorySegment.ofAddress(address, Long.MAX_VALUE, scope));
     }
 
-    static Builder builder(SegmentScope session) {
-        return new Builder(session);
+    static Builder builder(SegmentScope scope) {
+        return new Builder(scope);
     }
 
     @Override
@@ -171,12 +171,12 @@ public non-sealed class WinVaList implements VaList {
 
     public static non-sealed class Builder implements VaList.Builder {
 
-        private final SegmentScope session;
+        private final SegmentScope scope;
         private final List<SimpleVaArg> args = new ArrayList<>();
 
-        public Builder(SegmentScope session) {
-            ((MemorySessionImpl) session).checkValidState();
-            this.session = session;
+        public Builder(SegmentScope scope) {
+            ((MemorySessionImpl) scope).checkValidState();
+            this.scope = scope;
         }
 
         private Builder arg(MemoryLayout layout, Object value) {
@@ -216,7 +216,7 @@ public non-sealed class WinVaList implements VaList {
                 return EMPTY;
             }
 
-            MemorySegment segment = MemorySegment.allocateNative(VA_SLOT_SIZE_BYTES * args.size(), session);
+            MemorySegment segment = MemorySegment.allocateNative(VA_SLOT_SIZE_BYTES * args.size(), scope);
             MemorySegment cursor = segment;
 
             for (SimpleVaArg arg : args) {
@@ -225,7 +225,7 @@ public non-sealed class WinVaList implements VaList {
                     TypeClass typeClass = TypeClass.typeClassFor(arg.layout, false);
                     switch (typeClass) {
                         case STRUCT_REFERENCE -> {
-                            MemorySegment copy = MemorySegment.allocateNative(arg.layout, session);
+                            MemorySegment copy = MemorySegment.allocateNative(arg.layout, scope);
                             copy.copyFrom(msArg); // by-value
                             VH_address.set(cursor, copy);
                         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -68,8 +68,8 @@ public final class Windowsx64Linker extends AbstractLinker {
         return builder.build();
     }
 
-    public static VaList newVaListOfAddress(long address, SegmentScope session) {
-        return WinVaList.ofAddress(address, session);
+    public static VaList newVaListOfAddress(long address, SegmentScope scope) {
+        return WinVaList.ofAddress(address, scope);
     }
 
     public static VaList emptyVaList() {


### PR DESCRIPTION
This PR proposes changing variable names from `session` to `scope`. The proposed changes are only for the FFM API and not other parts like the Vector API and test classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298277](https://bugs.openjdk.org/browse/JDK-8298277): Replace "session" with "scope" for FFM access


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jdk20 pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/29.diff">https://git.openjdk.org/jdk20/pull/29.diff</a>

</details>
