### PR TITLE
8298649: JFR: RemoteRecordingStream support for checkpoint event sizes beyond u4

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -139,7 +139,7 @@ final class DiskRepository implements Closeable {
     private long typeId;
     private int typeIdshift;
     private int sizeShift;
-    private int payLoadSize;
+    private long payLoadSize;
     private int longValueshift;
     private int eventFieldSize;
     private int lastFlush;
@@ -225,7 +225,7 @@ final class DiskRepository implements Closeable {
     private void processEvent() {
         int left = currentByteArray.length - index;
         if (left >= payLoadSize) {
-            index += payLoadSize;
+            index = index + (int)payLoadSize;
             payLoadSize = 0;
             state = State.EVENT_SIZE;
         } else {

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -261,7 +261,7 @@ final class DiskRepository implements Closeable {
 
         eventFieldSize++;
         byte b = nextByte(false);
-        int v = (b & 0x7F);
+        long v = (b & 0x7F);
         payLoadSize += (v << sizeShift);
         if (b >= 0) {
             if (payLoadSize == 0) {


### PR DESCRIPTION
Could I have a review of a follow up fix to [JDK-8298129](https://bugs.openjdk.org/browse/JDK-8298129) to allow check point events with a size larger than u4 to be transferred over JMX.

Testing: jdk/jdk/jfr 

An overflow happens at line 265 if v and payLoadSize is not long values:

payLoadSize += (v << sizeShift);

The field should be renamed to payloadSize, but I will do it separately to keep this change easy to review.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298649](https://bugs.openjdk.org/browse/JDK-8298649): JFR: RemoteRecordingStream support for checkpoint event sizes beyond u4


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk20 pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/30.diff">https://git.openjdk.org/jdk20/pull/30.diff</a>

</details>
