### PR TITLE
8298727: Trees.getPath may crash for unnamed package

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -356,10 +356,12 @@ public class Enter extends JCTree.Visitor {
             tree.packge.complete(); // Find all classes in package.
 
             Env<AttrContext> topEnv = topLevelEnv(tree);
-            Env<AttrContext> packageEnv = isPkgInfo ? topEnv.dup(pd) : null;
+            Env<AttrContext> packageEnv = null;
 
             // Save environment of package-info.java file.
             if (isPkgInfo) {
+                packageEnv = topEnv.dup(pd != null ? pd : tree);
+
                 Env<AttrContext> env0 = typeEnvs.get(tree.packge);
                 if (env0 != null) {
                     JCCompilationUnit tree0 = env0.toplevel;

--- a/test/langtools/tools/javac/processing/model/EmptyPackageInfo.java
+++ b/test/langtools/tools/javac/processing/model/EmptyPackageInfo.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8298727
+ * @summary Verify empty package-info.java is handled properly
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.TestRunner toolbox.ToolBox EmptyPackageInfo
+ * @run main EmptyPackageInfo
+ */
+
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import com.sun.source.util.Trees;
+import java.util.ArrayList;
+import java.util.List;
+import javax.tools.ToolProvider;
+import toolbox.TestRunner;
+import toolbox.TestRunner.Test;
+import toolbox.ToolBox;
+
+public class EmptyPackageInfo extends TestRunner {
+
+    public static void main(String... args) throws Exception {
+        new EmptyPackageInfo().runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    public EmptyPackageInfo() {
+        super(System.err);
+    }
+
+    @Test
+    public void testEmptyPackageInfo(Path outerBase) throws Exception {
+        Path src = outerBase.resolve("src");
+        Path classes = outerBase.resolve("classes");
+        Path packInfo = src.resolve("package-info.java");
+
+        tb.writeFile(packInfo, "/**javadoc*/\n");
+        Files.createDirectories(classes);
+
+        var compiler = ToolProvider.getSystemJavaCompiler();
+
+        try (var fm = compiler.getStandardFileManager(null,
+                                                      null,
+                                                      null)) {
+            var task =
+                    (JavacTask) compiler.getTask(null,
+                                                 fm,
+                                                 null,
+                                                 null,
+                                                 null,
+                                                 fm.getJavaFileObjects(packInfo));
+            task.analyze();
+            var pack = task.getElements().getPackageElement("");
+            var trees = Trees.instance(task);
+            var packPath = trees.getPath(pack);
+            var packTree = packPath.getLeaf();
+            if (packTree.getKind() != Tree.Kind.COMPILATION_UNIT) {
+                throw new AssertionError("Unexpected tree kind: " + packTree.getKind());
+            }
+            var actualJavadoc = trees.getDocComment(packPath);
+            var expectedJavadoc = "javadoc";
+            if (!expectedJavadoc.equals(actualJavadoc)) {
+                throw new AssertionError("Unexpected javadoc, " +
+                                         "expected: " + expectedJavadoc +
+                                         ", got: " + actualJavadoc);
+            }
+        }
+    }
+
+    @Test
+    public void testMultipleFiles(Path outerBase) throws Exception {
+        Path src = outerBase.resolve("src");
+        Path classes = outerBase.resolve("classes");
+        Path packInfo1 = src.resolve("test1").resolve("package-info.java");
+        Path packInfo2 = src.resolve("test2").resolve("package-info.java");
+
+        tb.writeFile(packInfo1, "");
+        tb.writeFile(packInfo2, "");
+        Files.createDirectories(classes);
+
+        var compiler = ToolProvider.getSystemJavaCompiler();
+
+        try (var fm = compiler.getStandardFileManager(null,
+                                                      null,
+                                                      null)) {
+            var diags = new ArrayList<String>();
+            var task =
+                    (JavacTask) compiler.getTask(null,
+                                                 fm,
+                                                 d -> diags.add(d.getCode()),
+                                                 null,
+                                                 null,
+                                                 fm.getJavaFileObjects(packInfo1,
+                                                                       packInfo2));
+            task.analyze();
+            var expectedDiags =
+                    List.of("compiler.warn.pkg-info.already.seen");
+            if (!expectedDiags.equals(diags)) {
+                throw new AssertionError("Unexpected diags, " +
+                                         "expected: " + expectedDiags +
+                                         ", got: " + diags);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Considering an empty `package-info.java` file is normally accepted by javac (as a `package-info` for the unnamed module). But, if `Trees.getPath` is used on the unnamed package, a NPE occurs:
```
java.lang.NullPointerException: Cannot invoke "com.sun.tools.javac.tree.JCTree.accept(com.sun.tools.javac.tree.JCTree$Visitor)" because "tree" is null
at jdk.compiler/com.sun.tools.javac.tree.TreeInfo.declarationFor(TreeInfo.java:811)
at jdk.compiler/com.sun.tools.javac.model.JavacElements.getTreeAndTopLevel(JavacElements.java:779)
at jdk.compiler/com.sun.tools.javac.model.JavacElements.getTreeAndTopLevel(JavacElements.java:799)
at jdk.compiler/com.sun.tools.javac.api.JavacTrees.getPath(JavacTrees.java:331)
at jdk.compiler/com.sun.tools.javac.api.JavacTrees.getPath(JavacTrees.java:321)
```

The reason is that `Env.tree` is initialized to the package clause in `Enter.visitTopLevel`, but when the package clause is missing, `Env.tree` is `null`, leading to the error above.

The proposed fix is to set `Env.tree` to the top-level tree in this case, to keep it non-null. As the empty `package-info` can be compiled, it seems reasonable for the model to work on is as well, so a non-null tree needs to be set, and there's no other tree that could be used, I believe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298727](https://bugs.openjdk.org/browse/JDK-8298727): Trees.getPath may crash for unnamed package


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/jdk20 pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/31.diff">https://git.openjdk.org/jdk20/pull/31.diff</a>

</details>
