### PR TITLE
8298642: ParallelGC -XX:+UseNUMA eden spaces allocated on wrong node

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -314,9 +314,12 @@ void MutableNUMASpace::bias_region(MemRegion mr, int lgrp_id) {
     assert(region().contains(aligned_region), "Sanity");
     // First we tell the OS which page size we want in the given range. The underlying
     // large page can be broken down if we require small pages.
-    os::realign_memory((char*)aligned_region.start(), aligned_region.byte_size(), page_size());
+    const size_t os_align = UseLargePages ? page_size() : os::vm_page_size();
+    os::realign_memory((char*)aligned_region.start(), aligned_region.byte_size(), os_align);
     // Then we uncommit the pages in the range.
-    os::free_memory((char*)aligned_region.start(), aligned_region.byte_size(), page_size());
+    // The alignment_hint argument must be less than or equal to the small page
+    // size if not using large pages or else this function does nothing.
+    os::free_memory((char*)aligned_region.start(), aligned_region.byte_size(), os_align);
     // And make them local/first-touch biased.
     os::numa_make_local((char*)aligned_region.start(), aligned_region.byte_size(), lgrp_id);
   }


### PR DESCRIPTION
I noticed this when implementing JDK-8298482.  If UseAdaptiveSizePolicy and/or UseAdaptiveNUMAChunkSizing are enabled and UseLargePages is *not* enabled, part of the eden spaces managed by MutableNUMASpace end up bound to the wrong node.  This seems to be a regression caused by JDK-8283935, specifically the addition of

```
  set_page_size(alignment());
```

to MutableNUMASpace::initialize().  Previously the page size would have been equal to os::vm_page_size() unless UseLargePages was enabled.

In bias_region() we call os::free_memory() to uncommit a range of pages so that they can be later allocated on a different node, passing page_size() as the alignment_hint argument. However on Linux this does nothing if alignment_hint is greater than os::vm_page_size() and THP is not enabled, so the pages always remain bound to their original node (see os::pd_free_memory() in os_linux.cpp).

I think the solution here is to pass os::vm_page_size() as the alignment_hint when UseLargePages is disabled.

I tested SPECjbb on a dual-socket AArch64 system with -XX:+UseParallelGC -XX:+UseNUMA but otherwise default options and critical-jOPS improved by about 12% (averaged over several runs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298642](https://bugs.openjdk.org/browse/JDK-8298642): ParallelGC -XX:+UseNUMA eden spaces allocated on wrong node


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jdk20 pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/33.diff">https://git.openjdk.org/jdk20/pull/33.diff</a>

</details>
