### PR TITLE
8298785: gc/TestFullGCCount.java fails with "invalid boolean value: `null' for expression `vm.opt.ExplicitGCInvokesConcurrent'"

### DIFF
--- a/test/hotspot/jtreg/gc/TestFullGCCount.java
+++ b/test/hotspot/jtreg/gc/TestFullGCCount.java
@@ -30,7 +30,7 @@ package gc;
  * @comment Shenandoah has "ExplicitGCInvokesConcurrent" on by default
  * @requires !(vm.gc == "Shenandoah" & vm.opt.ExplicitGCInvokesConcurrent != false)
  * @comment G1 has separate counters for STW Full GC and concurrent GC.
- * @requires !(vm.gc == "G1" & vm.opt.ExplicitGCInvokesConcurrent)
+ * @requires !(vm.gc.G1 & vm.opt.ExplicitGCInvokesConcurrent == true)
  * @requires vm.gc != "Z"
  * @modules java.management
  * @run main/othervm -Xlog:gc gc.TestFullGCCount


### PR DESCRIPTION
Please review this fix to the change to gc/TestFullGCCount.java made in
JDK-8298296.  I got the syntax for the new @requires condition wrong, and
while it worked fine for the cases I tested, there are other cases encountered
in our CI where it doesn't work.

`!vm.opt.ExplicitGCInvokesConcurrent` => `vm.opt.ExplicitGCInvokesConcurrent == true`
The problem is that if the option isn't provided at all then the vm.opt
variable is null rather than true or false.  I previously only tested with
explicit true or false for that option.  Oops.

`vm.gc == "G1"` => `vm.gc.G1`
The problem is that if the GC is defaulted (not explicitly "G1") and
-XX:+ExplicitGCInvokesConcurrent then the test will be run when it shouldn't
be, and will fail as per JDK-8298296.

Testing:
Hand checked the following configurations, with the expected results:
<no options> => passed
`-XX:+UseG1GC` => passed
`-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent` => skipped
`-XX:+UseG1GC -XX:-ExplicitGCInvokesConcurrent` => passed
`-XX:+ExplicitGCInvokesConcurrent` => skipped
`-XX:-ExplicitGCInvokesConcurrent` => passed
`-XX:+UseParallelGC -XX:+ExplicitGCInvokesConcurrent` => passed

Currently waiting for mach5 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298785](https://bugs.openjdk.org/browse/JDK-8298785): gc/TestFullGCCount.java fails with "invalid boolean value: `null' for expression `vm.opt.ExplicitGCInvokesConcurrent'"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jdk20 pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/34.diff">https://git.openjdk.org/jdk20/pull/34.diff</a>

</details>
