### PR TITLE
8298376: ZGC: thaws stackChunk with stale oops

### DIFF
--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -92,6 +92,8 @@ public:
   inline void set_max_thawing_size(int value);
 
   inline oop cont() const;
+  template<typename P>
+  inline oop cont() const;
   inline void set_cont(oop value);
   template<typename P>
   inline void set_cont_raw(oop value);

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -86,7 +86,18 @@ inline void stackChunkOopDesc::set_max_thawing_size(int value)  {
   jdk_internal_vm_StackChunk::set_maxThawingSize(this, (jint)value);
 }
 
-inline oop stackChunkOopDesc::cont() const                { return jdk_internal_vm_StackChunk::cont(as_oop()); }
+inline oop stackChunkOopDesc::cont() const                { return UseCompressedOops ? cont<narrowOop>() : cont<oop>(); /* jdk_internal_vm_StackChunk::cont(as_oop()); */ }
+template<typename P>
+inline oop stackChunkOopDesc::cont() const                {
+  // The state of the cont oop is used by ZCollectedHeap::requires_barriers,
+  // to determine the age of the stackChunkOopDesc. For that to work, it is
+  // only the GC that is allowed to perform a load barrier on the oop.
+  // This function is used by non-GC code and therfore create a stack-local
+  // copy on the oop and perform the load barrier on that copy instead.
+  oop obj = jdk_internal_vm_StackChunk::cont_raw<P>(as_oop());
+  obj = (oop)NativeAccess<>::oop_load(&obj);
+  return obj;
+}
 inline void stackChunkOopDesc::set_cont(oop value)        { jdk_internal_vm_StackChunk::set_cont(this, value); }
 template<typename P>
 inline void stackChunkOopDesc::set_cont_raw(oop value)    { jdk_internal_vm_StackChunk::set_cont_raw<P>(this, value); }

--- a/src/hotspot/share/runtime/continuationJavaClasses.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.hpp
@@ -124,7 +124,8 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static inline void set_maxThawingSize(oop chunk, int value);
 
   // cont oop's processing is essential for the chunk's GC protocol
-  static inline oop cont(oop chunk);
+  template<typename P>
+  static inline oop cont_raw(oop chunk);
   static inline void set_cont(oop chunk, oop value);
   template<typename P>
   static inline void set_cont_raw(oop chunk, oop value);

--- a/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
@@ -81,8 +81,9 @@ inline void jdk_internal_vm_StackChunk::set_parent_access(oop chunk, oop value) 
   chunk->obj_field_put_access<decorators>(_parent_offset, value);
 }
 
-inline oop jdk_internal_vm_StackChunk::cont(oop chunk) {
-  return chunk->obj_field(_cont_offset);
+template<typename P>
+inline oop jdk_internal_vm_StackChunk::cont_raw(oop chunk) {
+  return (oop)RawAccess<>::oop_load(chunk->field_addr<P>(_cont_offset));
 }
 
 inline void jdk_internal_vm_StackChunk::set_cont(oop chunk, oop value) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298376](https://bugs.openjdk.org/browse/JDK-8298376): ZGC: thaws stackChunk with stale oops


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jdk20 pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/37.diff">https://git.openjdk.org/jdk20/pull/37.diff</a>

</details>
