### PR TITLE
8297979: ZGC: Ensure consistent MemoryUsage from MemoryMXBean.getHeapMemoryUsage()

### DIFF
--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -224,6 +224,10 @@ bool ZCollectedHeap::uses_stack_watermark_barrier() const {
   return true;
 }
 
+MemoryUsage ZCollectedHeap::memory_usage() {
+  return _heap.serviceability_memory_pool()->get_memory_usage();
+}
+
 GrowableArray<GCMemoryManager*> ZCollectedHeap::memory_managers() {
   GrowableArray<GCMemoryManager*> memory_managers(2);
   memory_managers.append(_heap.serviceability_cycle_memory_manager());

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -31,6 +31,7 @@
 #include "gc/z/zInitialize.hpp"
 #include "gc/z/zRuntimeWorkers.hpp"
 #include "memory/metaspace.hpp"
+#include "services/memoryUsage.hpp"
 
 class ZDirector;
 class ZDriver;
@@ -90,6 +91,7 @@ public:
 
   virtual bool uses_stack_watermark_barrier() const;
 
+  virtual MemoryUsage memory_usage();
   virtual GrowableArray<GCMemoryManager*> memory_managers();
   virtual GrowableArray<MemoryPool*> memory_pools();
 

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -47,42 +47,5 @@ serviceability/sa/ClhsdbPstack.java#core                      8248912   generic-
 
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64
 
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem001/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem002/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem003/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem004/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem005/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem006/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem007/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem008/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem009/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem010/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem011/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem012/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem013/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem014/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem015/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem016/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem017/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem018/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem019/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem020/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem021/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem022/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem023/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem024/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem025/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem026/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem027/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem028/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem029/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem030/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem031/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem032/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem033/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem034/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem035/TestDescription.java 8297979 generic-all
-vmTestbase/nsk/monitoring/stress/lowmem/lowmem036/TestDescription.java 8297979 generic-all
-
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter001/TestDescription.java 8298059 generic-x64
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter004/TestDescription.java 8298059 generic-x64


### PR DESCRIPTION
Please review this bugfix to ensure a consistent `MemoryUsage`object is returned when using `MemoryMXBean.getHeapMemoryUsage()`

**Summary**
In ZGC the `MemoryUsage` returned was created using the base implementation in `CollectedHead`. This implementation just queries the underlying heap for `used`, `capacity`and `max_capacity`, and since these values can be updated concurrently with ZGC we need to have a specialized implementation that handles this to ensure consistent values are returned. Such implementation is already present and used when the usage is quired through a `MemoryPool`, so this change just re-uses that.

**Testing**
Verified locally that this fixes the test that previously failed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297979](https://bugs.openjdk.org/browse/JDK-8297979): ZGC: Ensure consistent MemoryUsage from MemoryMXBean.getHeapMemoryUsage()


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/jdk20 pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/39.diff">https://git.openjdk.org/jdk20/pull/39.diff</a>

</details>
