### PR TITLE
8298888: ProblemList gc/g1/TestVerifyGCType.java on linux and macosx

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -86,3 +86,4 @@ vmTestbase/nsk/monitoring/stress/lowmem/lowmem036/TestDescription.java 8297979 g
 
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter001/TestDescription.java 8298059 generic-x64
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter004/TestDescription.java 8298059 generic-x64
+vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -87,3 +87,4 @@ vmTestbase/nsk/monitoring/stress/lowmem/lowmem036/TestDescription.java 8297979 g
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter001/TestDescription.java 8298059 generic-x64
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter004/TestDescription.java 8298059 generic-x64
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
+vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java 8298596 linux-x64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -80,6 +80,7 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293,8298073 macosx-x64,macosx-aarch64
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
+gc/g1/TestVerifyGCType.java 8298215 linux-all,macosx-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -98,6 +98,7 @@ runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/vthread/RedefineClass.java 8297286 generic-all
 runtime/vthread/TestObjectAllocationSampleEvent.java 8297286 generic-all
+runtime/StackGuardPages/TestStackGuardPages.java 8293452 linux-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A batch of trivial fixes to ProblemList tests:

[JDK-8298888](https://bugs.openjdk.org/browse/JDK-8298888) ProblemList gc/g1/TestVerifyGCType.java on linux and macosx
[JDK-8298889](https://bugs.openjdk.org/browse/JDK-8298889) ProblemList runtime/StackGuardPages/TestStackGuardPages.java on linux
[JDK-8298891](https://bugs.openjdk.org/browse/JDK-8298891) ProblemList vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java with ZGC
[JDK-8298892](https://bugs.openjdk.org/browse/JDK-8298892)
ProblemList vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java with ZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298888](https://bugs.openjdk.org/browse/JDK-8298888): ProblemList gc/g1/TestVerifyGCType.java on linux and macosx
 * [JDK-8298889](https://bugs.openjdk.org/browse/JDK-8298889): ProblemList runtime/StackGuardPages/TestStackGuardPages.java on linux
 * [JDK-8298891](https://bugs.openjdk.org/browse/JDK-8298891): ProblemList vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java with ZGC
 * [JDK-8298892](https://bugs.openjdk.org/browse/JDK-8298892): ProblemList vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java with ZGC


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.org/jdk20 pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/42.diff">https://git.openjdk.org/jdk20/pull/42.diff</a>

</details>
