### PR TITLE
8298905: Test "java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java" fails because the frames of instruction does not display

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java
@@ -54,6 +54,7 @@ public class PrintARGBImage implements Printable {
                     """;
 
             PassFailJFrame passFailJFrame = new PassFailJFrame(instruction, 10);
+            PassFailJFrame.positionTestWindow(null, PassFailJFrame.Position.HORIZONTAL);
             try {
                 PrinterJob pj = PrinterJob.getPrinterJob();
                 pj.setPrintable(new PrintARGBImage());

--- a/test/jdk/java/awt/print/PrinterJob/PageRangesDlgTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRangesDlgTest.java
@@ -81,6 +81,7 @@ public class PageRangesDlgTest implements Printable {
                 """;
 
         PassFailJFrame passFailJFrame = new PassFailJFrame(instruction, 10);
+        PassFailJFrame.positionTestWindow(null, PassFailJFrame.Position.HORIZONTAL);
         showPrintDialogs();
         passFailJFrame.awaitAndCheck();
     }

--- a/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
@@ -22,25 +22,23 @@
  */
 
 /* @test
- * @bug 8054572
+ * @bug 6445283
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
- * @summary Tests if JComboBox displays correctly when editable/non-editable
+ * @summary Tests if ProgressMonitorInputStream reports progress accurately
  * @run main/manual ProgressTest
  */
 
 import java.io.InputStream;
 
-import javax.swing.JFrame;
 import javax.swing.ProgressMonitorInputStream;
-import javax.swing.SwingUtilities;
 
 public class ProgressTest {
 
     private static final String instructionsText =
-            "A ProgressMonitor will be shown." +
-            " If it shows blank progressbar after 2048MB bytes read,"+
-            " press Fail else press Pass";
+            "A ProgressMonitor will be shown.\n" +
+                    " If it shows blank progressbar after 2048MB bytes read,\n"+
+                    " press Fail else press Pass";
 
     public static void main(String[] args) throws Exception {
 

--- a/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
@@ -37,8 +37,8 @@ public class ProgressTest {
 
     private static final String instructionsText =
             "A ProgressMonitor will be shown.\n" +
-                    " If it shows blank progressbar after 2048MB bytes read,\n"+
-                    " press Fail else press Pass";
+            " If it shows blank progressbar after 2048MB bytes read,\n"+
+            " press Fail else press Pass";
 
     public static void main(String[] args) throws Exception {
 

--- a/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
@@ -42,12 +42,11 @@ public class ProgressTest {
             " If it shows blank progressbar after 2048MB bytes read,"+
             " press Fail else press Pass";
 
-    private static JFrame frame;
-
     public static void main(String[] args) throws Exception {
 
         PassFailJFrame pfjFrame = new PassFailJFrame("JScrollPane "
                 + "Test Instructions", instructionsText, 5);
+        PassFailJFrame.positionTestWindow(null, PassFailJFrame.Position.VERTICAL);
 
         final long SIZE = (long) (Integer.MAX_VALUE * 1.5);
 
@@ -85,6 +84,7 @@ public class ProgressTest {
             }
         };
         thread.start();
+
         pfjFrame.awaitAndCheck();
     }
 }


### PR DESCRIPTION
openjdk/jdk#9525 has changed behavior of PassFailJFrame.
it doesn't call `setVisible()` from its constructor on instruction window anymore and some tests were not ready for that.

So adding `positionTestWindow()` fixes the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298905](https://bugs.openjdk.org/browse/JDK-8298905): Test "java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java" fails because the frames of instruction does not display


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [6ae5260e](https://git.openjdk.org/jdk20/pull/46/files/6ae5260e45ea348e8df0f5370e4080bdd63eac20)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/jdk20 pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/46.diff">https://git.openjdk.org/jdk20/pull/46.diff</a>

</details>
