### PR TITLE
8298970: Problem list java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -187,6 +187,7 @@ java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all
+java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java 8298910 linux-all
 
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all


### PR DESCRIPTION
This test was stabilized and removed from problemlist recently.
Looks like previous efforts of improving test stability was not enough to prevent crashed of a system.
It still may crash Xserver somehow(but never in single test run), this prevents normal ATR.

So problem listing the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298970](https://bugs.openjdk.org/browse/JDK-8298970): Problem list java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jdk20 pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/48.diff">https://git.openjdk.org/jdk20/pull/48.diff</a>

</details>
