### PR TITLE
8298893: Rename option UsePolyIntrinsics to UsePoly1305Intrinsics 

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3709,7 +3709,7 @@ void StubGenerator::generate_initial() {
     StubRoutines::_updateBytesCRC32 = generate_updateBytesCRC32();
   }
 
-  if (UsePolyIntrinsics) {
+  if (UsePoly1305Intrinsics) {
     StubRoutines::_poly1305_processBlocks = generate_poly1305_processBlocks();
   }
 

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1351,14 +1351,14 @@ void VM_Version::get_processor_features() {
 
 #ifdef _LP64
   if (supports_avx512ifma() && supports_avx512vlbw() && MaxVectorSize >= 64) {
-    if (FLAG_IS_DEFAULT(UsePolyIntrinsics)) {
-      FLAG_SET_DEFAULT(UsePolyIntrinsics, true);
+    if (FLAG_IS_DEFAULT(UsePoly1305Intrinsics)) {
+      FLAG_SET_DEFAULT(UsePoly1305Intrinsics, true);
     }
   } else
 #endif
-  if (UsePolyIntrinsics) {
+  if (UsePoly1305Intrinsics) {
     warning("Intrinsics for Poly1305 crypto hash functions not available on this CPU.");
-    FLAG_SET_DEFAULT(UsePolyIntrinsics, false);
+    FLAG_SET_DEFAULT(UsePoly1305Intrinsics, false);
   }
 
 #ifdef _LP64

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -483,7 +483,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
     if (!UseBASE64Intrinsics) return true;
     break;
   case vmIntrinsics::_poly1305_processBlocks:
-    if (!UsePolyIntrinsics) return true;
+    if (!UsePoly1305Intrinsics) return true;
     break;
   case vmIntrinsics::_updateBytesCRC32C:
   case vmIntrinsics::_updateDirectByteBufferCRC32C:

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -7003,7 +7003,7 @@ bool LibraryCallKit::inline_base64_decodeBlock() {
 bool LibraryCallKit::inline_poly1305_processBlocks() {
   address stubAddr;
   const char *stubName;
-  assert(UsePolyIntrinsics, "need Poly intrinsics support");
+  assert(UsePoly1305Intrinsics, "need Poly intrinsics support");
   assert(callee()->signature()->size() == 5, "poly1305_processBlocks has %d parameters", callee()->signature()->size());
   stubAddr = StubRoutines::poly1305_processBlocks();
   stubName = "poly1305_processBlocks";

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -238,7 +238,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, UseBASE64Intrinsics, false,                                 \
           "Use intrinsics for java.util.Base64")                            \
                                                                             \
-  product(bool, UsePolyIntrinsics, false, DIAGNOSTIC,                       \
+  product(bool, UsePoly1305Intrinsics, false, DIAGNOSTIC,                       \
           "Use intrinsics for sun.security.util.math.intpoly")              \
                                                                             \
   product(size_t, LargePageSizeInBytes, 0,                                  \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -238,7 +238,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, UseBASE64Intrinsics, false,                                 \
           "Use intrinsics for java.util.Base64")                            \
                                                                             \
-  product(bool, UsePoly1305Intrinsics, false, DIAGNOSTIC,                       \
+  product(bool, UsePoly1305Intrinsics, false, DIAGNOSTIC,                   \
           "Use intrinsics for sun.security.util.math.intpoly")              \
                                                                             \
   product(size_t, LargePageSizeInBytes, 0,                                  \


### PR DESCRIPTION
Fix for better documentation. FYI @jnimeh

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298893](https://bugs.openjdk.org/browse/JDK-8298893): Rename option UsePolyIntrinsics to UsePoly1305Intrinsics


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to [a4faddeb](https://git.openjdk.org/jdk20/pull/49/files/a4faddeb2d36eb82468a36e9f7def7c635e9c252)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [a4faddeb](https://git.openjdk.org/jdk20/pull/49/files/a4faddeb2d36eb82468a36e9f7def7c635e9c252)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/jdk20 pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/49.diff">https://git.openjdk.org/jdk20/pull/49.diff</a>

</details>
