### PR TITLE
8298976: ProblemList java/util/concurrent/ExecutorService/CloseTest.java on macosx-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -167,5 +167,6 @@ vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEa
 
 vmTestbase/nsk/stress/except/except012.java 8297977 generic-all
 vmTestbase/nsk/stress/strace/strace002.java 8288912 macosx-x64,windows-x64
+vmTestbase/nsk/stress/strace/strace003.java 8297824 macosx-x64,windows-x64
 vmTestbase/nsk/stress/strace/strace004.java 8297824 macosx-x64,windows-x64
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -166,5 +166,6 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
 vmTestbase/nsk/stress/except/except012.java 8297977 generic-all
+vmTestbase/nsk/stress/strace/strace002.java 8288912 macosx-x64,windows-x64
 vmTestbase/nsk/stress/strace/strace004.java 8297824 macosx-x64,windows-x64
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -717,6 +717,7 @@ com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-al
 java/util/Locale/LocaleProvidersRun.java                        8268379 macosx-x64
 sun/util/locale/provider/CalendarDataRegression.java            8268379 macosx-x64
 java/util/concurrent/forkjoin/AsyncShutdownNow.java             8286352 linux-all,windows-x64
+java/util/concurrent/ExecutorService/CloseTest.java             8288899 macosx-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
A batch a trivial fixes to ProblemList tests:
[JDK-8298976](https://bugs.openjdk.org/browse/JDK-8298976) ProblemList java/util/concurrent/ExecutorService/CloseTest.java on macosx-aarch64
[JDK-8298977](https://bugs.openjdk.org/browse/JDK-8298977) ProblemList vmTestbase/nsk/stress/strace/strace002.java on 2 platforms
[JDK-8298978](https://bugs.openjdk.org/browse/JDK-8298978) ProblemList vmTestbase/nsk/stress/strace/strace003.java on 2 platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298976](https://bugs.openjdk.org/browse/JDK-8298976): ProblemList java/util/concurrent/ExecutorService/CloseTest.java on macosx-aarch64
 * [JDK-8298977](https://bugs.openjdk.org/browse/JDK-8298977): ProblemList vmTestbase/nsk/stress/strace/strace002.java on 2 platforms
 * [JDK-8298978](https://bugs.openjdk.org/browse/JDK-8298978): ProblemList vmTestbase/nsk/stress/strace/strace003.java on 2 platforms


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jdk20 pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/50.diff">https://git.openjdk.org/jdk20/pull/50.diff</a>

</details>
