### PR TITLE
8298987: ProblemList jdk/internal/vm/Continuation/Fuzz.java#default with ZGC on X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -151,6 +151,7 @@ vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.ja
 vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8277812 generic-all
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8073470 linux-all
+vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java 8288911 macosx-x64
 
 vmTestbase/gc/lock/jni/jnilock002/TestDescription.java 8192647 generic-all
 

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -26,3 +26,5 @@
 # List of quarantined tests for testing with ZGC.
 #
 #############################################################################
+
+jdk/internal/vm/Continuation/Fuzz.java#default 8298058 generic-x64

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -28,3 +28,5 @@
 #############################################################################
 
 jdk/internal/vm/Continuation/Fuzz.java#default 8298058 generic-x64
+java/lang/Thread/virtual/stress/Skynet.java#id0 8298894 macosx-x64
+java/lang/Thread/virtual/stress/Skynet.java#id1 8298894 macosx-x64


### PR DESCRIPTION
A batch of trivial fixes to ProblemList tests:
[JDK-8298987](https://bugs.openjdk.org/browse/JDK-8298987) ProblemList jdk/internal/vm/Continuation/Fuzz.java#default with ZGC on X64
[JDK-8298989](https://bugs.openjdk.org/browse/JDK-8298989) ProblemList vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java on macosx-x64
[JDK-8298990](https://bugs.openjdk.org/browse/JDK-8298990) ProblemList java/lang/Thread/virtual/stress/Skynet.java subtests with ZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298987](https://bugs.openjdk.org/browse/JDK-8298987): ProblemList jdk/internal/vm/Continuation/Fuzz.java#default with ZGC on X64
 * [JDK-8298989](https://bugs.openjdk.org/browse/JDK-8298989): ProblemList vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/TestDescription.java on macosx-x64
 * [JDK-8298990](https://bugs.openjdk.org/browse/JDK-8298990): ProblemList java/lang/Thread/virtual/stress/Skynet.java subtests with ZGC


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jdk20 pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/51.diff">https://git.openjdk.org/jdk20/pull/51.diff</a>

</details>
