### PR TITLE
8298894: java/lang/Thread/virtual/stress/Skynet.java timed out and threw OutOfMemoryError

### DIFF
--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -28,5 +28,3 @@
 #############################################################################
 
 jdk/internal/vm/Continuation/Fuzz.java#default 8298058 generic-x64
-java/lang/Thread/virtual/stress/Skynet.java#id0 8298894 macosx-x64
-java/lang/Thread/virtual/stress/Skynet.java#id1 8298894 macosx-x64

--- a/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
@@ -26,7 +26,7 @@
  * @summary Stress test virtual threads with a variation of the Skynet 1M benchmark
  * @requires vm.continuations
  * @enablePreview
- * @run main/othervm/timeout=300 Skynet
+ * @run main/othervm/timeout=300 -Xmx1g Skynet
  */
 
 /*
@@ -35,7 +35,7 @@
  * @requires vm.gc.Z
  * @enablePreview
  * @run main/othervm/timeout=300 -XX:+UnlockDiagnosticVMOptions
- *     -XX:+ZVerifyViews -XX:ZCollectionInterval=0.01 Skynet
+ *     -XX:+ZVerifyViews -XX:ZCollectionInterval=0.01 -Xmx1g Skynet
  */
 
 import java.util.concurrent.BlockingQueue;


### PR DESCRIPTION
This test started timing out recently on macosx-x64 when testing debug builds with ZGC. The test needs more heap so that it doesn't fail with OOME.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298894](https://bugs.openjdk.org/browse/JDK-8298894): java/lang/Thread/virtual/stress/Skynet.java timed out and threw OutOfMemoryError


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jdk20 pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/54.diff">https://git.openjdk.org/jdk20/pull/54.diff</a>

</details>
