### PR TITLE
8298947: compiler/codecache/MHIntrinsicAllocFailureTest.java fails intermittently

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/MHIntrinsicAllocFailureTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/MHIntrinsicAllocFailureTest.java
@@ -27,6 +27,7 @@
  * @bug 8295724
  * @requires vm.compMode == "Xmixed"
  * @requires vm.opt.TieredCompilation == null | vm.opt.TieredCompilation == true
+ * @requires vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4
  * @summary test allocation failure of method handle intrinsic in profiled/non-profiled space
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
The test doesn't work when using -XX:TieredStopAtLevel to switch off C2 compilation. Don't run the test in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298947](https://bugs.openjdk.org/browse/JDK-8298947): compiler/codecache/MHIntrinsicAllocFailureTest.java fails intermittently


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/jdk20 pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/55.diff">https://git.openjdk.org/jdk20/pull/55.diff</a>

</details>
