### PR TITLE
JDK-8277074: Qualified exported types show up in JavaDoc

### DIFF
--- a/src/java.base/share/classes/jdk/internal/event/Event.java
+++ b/src/java.base/share/classes/jdk/internal/event/Event.java
@@ -28,6 +28,8 @@ package jdk.internal.event;
 /**
  * Base class for events, to be subclassed in order to define events and their
  * fields.
+ *
+ * @hidden
  */
 public abstract class Event {
     /**

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -150,6 +150,9 @@ public class VectorSupport {
 
     public static class VectorSpecies<E> {}
 
+    /**
+     * @hidden
+     */
     public static class VectorPayload {
         private final Object payload; // array of primitives
 
@@ -162,17 +165,26 @@ public class VectorSupport {
         }
     }
 
+    /**
+     * @hidden
+     */
     public static class Vector<E> extends VectorPayload {
         public Vector(Object payload) {
             super(payload);
         }
     }
 
+    /**
+     * @hidden
+     */
     public static class VectorShuffle<E> extends VectorPayload {
         public VectorShuffle(Object payload) {
             super(payload);
         }
     }
+    /**
+     * @hidden
+     */
     public static class VectorMask<E> extends VectorPayload {
         public VectorMask(Object payload) {
             super(payload);


### PR DESCRIPTION
This `noreg-doc` PR has been moved over from the mainline repository, the original PR is openjdk/jdk#11163. 

The purpose is to hide internal classes in generated documentation by adding doc comments containing a @hidden tag. I verified the fix by making sure the internal vector and event classes no longer show up in the generated documentation tree.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277074](https://bugs.openjdk.org/browse/JDK-8277074): Qualified exported types show up in JavaDoc


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/jdk20 pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/56.diff">https://git.openjdk.org/jdk20/pull/56.diff</a>

</details>
