### PR TITLE
8298162: Test PrintClasses hits assert when run with code that retransform classes

### DIFF
--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,9 @@ void fieldDescriptor::reinitialize(InstanceKlass* ik, int index) {
   if (_cp.is_null() || field_holder() != ik) {
     _cp = constantPoolHandle(Thread::current(), ik->constants());
     // _cp should now reference ik's constant pool; i.e., ik is now field_holder.
-    assert(field_holder() == ik, "must be already initialized to this class");
+    // If the class is a scratch class, the constant pool points to the original class,
+    // but that's ok because of constant pool merging.
+    assert(field_holder() == ik || ik->is_scratch_class(), "must be already initialized to this class");
   }
   FieldInfo* f = ik->field(index);
   _access_flags = accessFlags_from(f->access_flags());

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
@@ -33,7 +33,8 @@
 /*
  * @test
  * @bug 8298162
- * @summary Test jcmd VM.classes
+ * @summary Test jcmd VM.classes with JFR
+ * @requires vm.hasJFR
  * @library /test/lib
  * @run main/othervm -XX:StartFlightRecording PrintClasses
  */

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
@@ -30,6 +30,14 @@
  * @run main/othervm PrintClasses
  */
 
+/*
+ * @test
+ * @bug 8298162
+ * @summary Test jcmd VM.classes
+ * @library /test/lib
+ * @run main/othervm -XX:StartFlightRecording PrintClasses
+ */
+
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.JDKToolFinder;
 


### PR DESCRIPTION
Allow scratch class to print InstanceKlass fields and not crash.  We might enhance InstanceKlass::print_on() to print more of the misc_flags information in the future so this output (rarely seen) doesn't confuse people.
Tested with failing test case, and tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298162](https://bugs.openjdk.org/browse/JDK-8298162): Test PrintClasses hits assert when run with code that retransform classes


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d64edd47](https://git.openjdk.org/jdk20/pull/57/files/d64edd477bed8e5a1a57ed68a58e0d9642878a12)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jdk20 pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/57.diff">https://git.openjdk.org/jdk20/pull/57.diff</a>

</details>
