### PR TITLE
8298061: vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java failed with "fatal error: refcount has gone to zero"

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -291,13 +291,11 @@ void PlaceholderTable::find_and_remove(Symbol* name, ClassLoaderData* loader_dat
   PlaceholderEntry* probe = get_entry(name, loader_data);
   if (probe != NULL) {
     log(name, probe, "find_and_remove", action);
-    bool empty = probe->remove_seen_thread(thread, action);
-    if (empty && action == LOAD_SUPER) {
-      probe->set_supername(nullptr);
-    }
+    probe->remove_seen_thread(thread, action);
     // If no other threads using this entry, and this thread is not using this entry for other states
     if ((probe->superThreadQ() == NULL) && (probe->loadInstanceThreadQ() == NULL)
         && (probe->defineThreadQ() == NULL) && (probe->definer() == NULL)) {
+      probe->clear_supername();
       remove_entry(name, loader_data);
     }
   }

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -291,11 +291,13 @@ void PlaceholderTable::find_and_remove(Symbol* name, ClassLoaderData* loader_dat
   PlaceholderEntry* probe = get_entry(name, loader_data);
   if (probe != NULL) {
     log(name, probe, "find_and_remove", action);
-    probe->remove_seen_thread(thread, action);
+    bool empty = probe->remove_seen_thread(thread, action);
+    if (empty && action == LOAD_SUPER) {
+      probe->set_supername(nullptr);
+    }
     // If no other threads using this entry, and this thread is not using this entry for other states
     if ((probe->superThreadQ() == NULL) && (probe->loadInstanceThreadQ() == NULL)
         && (probe->defineThreadQ() == NULL) && (probe->definer() == NULL)) {
-      probe->clear_supername();
       remove_entry(name, loader_data);
     }
   }

--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -111,6 +111,10 @@ class PlaceholderEntry {
       Symbol::maybe_increment_refcount(_supername);
     }
   }
+  void               clear_supername() {
+    Symbol::maybe_decrement_refcount(_supername);
+    _supername = nullptr;
+  }
 
   JavaThread*        definer()             const {return _definer; }
   void               set_definer(JavaThread* definer) { _definer = definer; }

--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -105,13 +105,11 @@ class PlaceholderEntry {
 
   Symbol*            supername()           const { return _supername; }
   void               set_supername(Symbol* supername) {
-    Symbol::maybe_decrement_refcount(_supername);
-    _supername = supername;
-    Symbol::maybe_increment_refcount(_supername);
-  }
-  void               clear_supername() {
-    Symbol::maybe_decrement_refcount(_supername);
-    _supername = nullptr;
+    if (supername != _supername) {
+      Symbol::maybe_decrement_refcount(_supername);
+      _supername = supername;
+      Symbol::maybe_increment_refcount(_supername);
+    }
   }
 
   JavaThread*        definer()             const {return _definer; }


### PR DESCRIPTION
Please review this limited fix to make symbol refcount not go to zero for the placeholder supername field. This supername field is to detect ClassCircularityError for parallel capable class loaders without deadlocking.
ie. t1 : Class A (lock object for A) -> super B (wait for lock object for B)
t2: Class B (lock object for B) -> super A (wait for lock object for A).

We get the supername field out of the placeholder table to do the check for super class CCE but the reference count in the placeholder table for this name can be one. The fix is not to decrement and increment if the name is the same.

Retesting with tier1-4 in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298061](https://bugs.openjdk.org/browse/JDK-8298061): vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java failed with "fatal error: refcount has gone to zero"


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jdk20 pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/58.diff">https://git.openjdk.org/jdk20/pull/58.diff</a>

</details>
