### PR TITLE
8298699: java/lang/reflect/IllegalArgumentsTest.java times out with slowdebug bits

### DIFF
--- a/test/jdk/java/lang/reflect/IllegalArgumentsTest.java
+++ b/test/jdk/java/lang/reflect/IllegalArgumentsTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8277964
  * @summary Test IllegalArgumentException be thrown when an argument is invalid
- * @run testng/othervm IllegalArgumentsTest
+ * @run testng/othervm/timeout=180 IllegalArgumentsTest
  */
 
 import java.lang.reflect.Constructor;


### PR DESCRIPTION
A trivial fix to slightly increase the default timeout so that java/lang/reflect/IllegalArgumentsTest.java
passes with slowdebug bits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298699](https://bugs.openjdk.org/browse/JDK-8298699): java/lang/reflect/IllegalArgumentsTest.java times out with slowdebug bits


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/jdk20 pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/60.diff">https://git.openjdk.org/jdk20/pull/60.diff</a>

</details>
