### PR TITLE
8298588: WebSockets: HandshakeUrlEncodingTest unnecessarily depends on a response body

### DIFF
--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -112,21 +112,22 @@ public class HandshakeUrlEncodingTest {
                     .join();
                 fail("Expected to throw");
             } catch (CompletionException ce) {
-                Throwable t = getCompletionCause(ce);
+                final Throwable t = getCompletionCause(ce);
                 if (!(t instanceof WebSocketHandshakeException)) {
                     throw new AssertionError("Unexpected exception", t);
                 }
-                WebSocketHandshakeException wse = (WebSocketHandshakeException) t;
+                final WebSocketHandshakeException wse = (WebSocketHandshakeException) t;
                 assertNotNull(wse.getResponse());
-                assertNotNull(wse.getResponse().body());
-                assertEquals(wse.getResponse().body().getClass(), String.class);
-                String body = (String)wse.getResponse().body();
-                String expectedBody = "/?&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
+                assertNotNull(wse.getResponse().uri());
+                assertNotNull(wse.getResponse().statusCode());
+                final String rawQuery = wse.getResponse().uri().getRawQuery();
+                final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
+                assertEquals(rawQuery, expectedRawQuery);
+                final String body = (String) wse.getResponse().body();
+                final String expectedBody = "/?" + expectedRawQuery;
                 assertEquals(body, expectedBody);
                 out.println("Status code is " + wse.getResponse().statusCode());
-                out.println("Response is " + body);
-                assertNotNull(wse.getResponse().statusCode());
-                out.println("Status code is " + wse.getResponse().statusCode());
+                out.println("Response is " + wse.getResponse());
                 assertEquals(wse.getResponse().statusCode(), 400);
             }
         }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8298588](https://bugs.openjdk.org/browse/JDK-8298588), commit [909d0cb4](https://github.com/openjdk/jdk/commit/909d0cb4d9475fd367b8bc64a6b50c5a324e9a01) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Michal Karm Babacek on 16 Dec 2022 and was reviewed by Daniel Fuchs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298588](https://bugs.openjdk.org/browse/JDK-8298588): WebSockets: HandshakeUrlEncodingTest unnecessarily depends on a response body


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jdk20 pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/63.diff">https://git.openjdk.org/jdk20/pull/63.diff</a>

</details>
