### PR TITLE
8298176: remove OpaqueZeroTripGuardPostLoop once main-loop disappears

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1705,7 +1705,7 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_n
   // pre-loop, the main-loop may not execute at all.  Later in life this
   // zero-trip guard will become the minimum-trip guard when we unroll
   // the main-loop.
-  Node *min_opaq = new OpaqueZeroTripGuardNode(C, limit);
+  Node *min_opaq = new OpaqueZeroTripGuardNode(C, limit, b_test);
   Node *min_cmp  = new CmpINode(pre_incr, min_opaq);
   Node *min_bol  = new BoolNode(min_cmp, b_test);
   register_new_node(min_opaq, new_pre_exit);
@@ -1994,7 +1994,7 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
   // (the previous loop trip-counter exit value) because we will be changing
   // the exit value (via additional unrolling) so we cannot constant-fold away the zero
   // trip guard until all unrolling is done.
-  Node *zer_opaq = new OpaqueZeroTripGuardNode(C, incr);
+  Node *zer_opaq = new OpaqueZeroTripGuardNode(C, incr, main_end->test_trip());
   Node *zer_cmp = new CmpINode(zer_opaq, limit);
   Node *zer_bol = new BoolNode(zer_cmp, main_end->test_trip());
   register_new_node(zer_opaq, new_main_exit);

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -27,6 +27,7 @@
 
 #include "opto/node.hpp"
 #include "opto/opcodes.hpp"
+#include "subnode.hpp"
 
 //------------------------------Opaque1Node------------------------------------
 // A node to prevent unwanted optimizations.  Allows constant folding.
@@ -72,9 +73,16 @@ class OpaqueLoopStrideNode : public Opaque1Node {
 
 class OpaqueZeroTripGuardNode : public Opaque1Node {
 public:
-  OpaqueZeroTripGuardNode(Compile* C, Node *n) : Opaque1Node(C, n) {
+  // This captures the test that returns true when the loop is entered. It depends on whether the loop goes up or down.
+  // This is used by CmpINode::Value.
+  BoolTest::mask _loop_entered_mask;
+  OpaqueZeroTripGuardNode(Compile* C, Node* n, BoolTest::mask loop_entered_test) :
+          Opaque1Node(C, n), _loop_entered_mask(loop_entered_test) {
   }
   virtual int Opcode() const;
+  virtual uint size_of() const {
+    return sizeof(*this);
+  }
 };
 
 //------------------------------Opaque3Node------------------------------------

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1678,6 +1678,13 @@ void PhaseIterGVN::add_users_to_worklist( Node *n ) {
         }
       }
     }
+    if (use->Opcode() == Op_OpaqueZeroTripGuard) {
+      assert(use->outcnt() <= 1, "OpaqueZeroTripGuard can't be shared");
+      if (use->outcnt() == 1) {
+        Node* cmp = use->unique_out();
+        _worklist.push(cmp);
+      }
+    }
   }
 }
 
@@ -1848,6 +1855,7 @@ void PhaseCCP::push_more_uses(Unique_Node_List& worklist, Node* parent, const No
   push_loadp(worklist, use);
   push_and(worklist, parent, use);
   push_cast_ii(worklist, parent, use);
+  push_opaque_zero_trip_guard(worklist, use);
 }
 
 
@@ -1965,6 +1973,12 @@ void PhaseCCP::push_cast_ii(Unique_Node_List& worklist, const Node* parent, cons
         push_if_not_bottom_type(worklist, cast_ii);
       }
     }
+  }
+}
+
+void PhaseCCP::push_opaque_zero_trip_guard(Unique_Node_List& worklist, const Node* use) const {
+  if (use->Opcode() == Op_OpaqueZeroTripGuard) {
+    push_if_not_bottom_type(worklist, use->unique_out());
   }
 }
 

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -596,6 +596,7 @@ class PhaseCCP : public PhaseIterGVN {
   static void push_load_barrier(Unique_Node_List& worklist, const BarrierSetC2* barrier_set, const Node* use);
   void push_and(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
   void push_cast_ii(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
+  void push_opaque_zero_trip_guard(Unique_Node_List& worklist, const Node* use) const;
 
  public:
   PhaseCCP( PhaseIterGVN *igvn ); // Compute conditional constants

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -153,6 +153,7 @@ public:
   virtual int Opcode() const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type *sub( const Type *, const Type * ) const;
+  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //------------------------------CmpUNode---------------------------------------

--- a/test/hotspot/jtreg/compiler/loopopts/TestOpaqueZeroTripGuardPostLoopRemoval.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestOpaqueZeroTripGuardPostLoopRemoval.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8298176
+ * @summary Must remove OpaqueZeroTripGuardPostLoop after main loop disappears else
+ *          the zero-trip-guard of the post loop cannot die and leaves an inconsistent
+ *          graph behind.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *      -XX:CompileCommand=compileonly,TestOpaqueZeroTripGuardPostLoopRemoval::test*
+ *      -XX:CompileCommand=dontinline,TestOpaqueZeroTripGuardPostLoopRemoval::*
+ *      TestOpaqueZeroTripGuardPostLoopRemoval
+ */
+
+public class TestOpaqueZeroTripGuardPostLoopRemoval {
+    static long x;
+
+    public static void main(String[] strArr) {
+        test_001();
+        test_002();
+        try {
+            test_003();
+        } catch (Exception e) {
+            // Expected
+        }
+        test_004();
+        test_005();
+    }
+
+    static void test_001() {
+        int b = 6;
+        for (long l = 1; l < 9; l++) {
+            b++;
+        }
+        for (int i = 1; i < 1000; i*=2) {
+            for (int j = 1; j < 2; j++) {
+                x = b + 1;
+            }
+        }
+    }
+
+    static void test_002() {
+        int b = 6;
+        for (long l = 60; l < 3000; l+=3) {
+            // bounds of loop: no work for post loop
+            b += 33; // any multiple of iv step
+        }
+        for (int i = 1; i < 1000; i*=2) {
+            for (int j = 1; j < 2; j++) {
+                x = b + 1;
+            }
+        }
+    }
+
+    static void dontInline() {
+        throw new RuntimeException();
+    }
+
+    static int test_003() {
+        int y = 3;
+        for (int i = 0; i < 9; ) {
+            for (long l = 1; l < 5; l++) {
+                y *= 2;
+            }
+            while (true) {
+                dontInline();
+            }
+        }
+        return y;
+    }
+
+    static void test_004() {
+        for (int i2 = 4; i2 < 13; i2++) {
+            double d = 56;
+            for (long l = 1; l < 5; l++) {
+                d = d + 3;
+            }
+            for (int i = 0; i < 10; i++) {
+                for (int d2 = i2; d2 < 2; d2 = 3) {
+                }
+            }
+        }
+    }
+
+    public static int test_005() {
+        long arr[]=new long[400];
+        for (int i = 3; i < 177; i++) {
+            for (int j = 0; j < 10; j++){}
+        }
+        int y = 0;
+        for (int i = 15; i < 356; i++) {
+            // Inner loop prevents strip-mining of outer loop
+            // later, inner loop is removed, so outer does pre-main-post without strip-mining
+            for (int j = 0; j < 10; j++){
+                y |= 1;
+            }
+        }
+        return y;
+    }
+}
+


### PR DESCRIPTION
As described in https://github.com/openjdk/jdk20/pull/22, the bug is
caused by the iv phi of a post loop that becomes top but because the
post loop is guarded by an opaque node, the control flow remains
alive.

The fix I propose is based on this comment Vladimir made:
https://github.com/openjdk/jdk20/pull/22#issuecomment-1349570615

When CmpINode::Value() encounters a (CmpI (OpaqueZeroTripGuard in1)
in2), it runs Value() on (CmpI in1 in2) and if it constant folds so
that the loop is not taken, returns that result. Translating "loop not
taken" into an actual CmpI type depends on whether the loop goes up or
down. To make the check above possible, OpaqueZeroTripGuard includes
the BoolTest::mask that causes the loop to be executed at the zero
trip guard.

The new logic in CmpINode::Value() is executed for both the main and
post loop zero trip guards (while the bug was only seen AFAIK with the
post loop) because I expect the same bug to exist with the main loop.

For the main loop, this works because initially the loop should be
executed and as optimizations proceed and adjust the zero trip guard,
the range of iterations executed in the loop should narrow (and never
widen). We may then end up with no iterations executed in the loop. No
further optimizations would make the main loop executable again. It's
then fine to fold the zero trip guard as we're done with
optimizations.

This works for the post loop because the compiler has no way to tell
whether it's executed or not as long as there's a main loop: the zero
trip guard then takes as input a phi that merges the pre and main loop
ivs. For the case of a loop going up, the zero trip guard should
initially test whether [init, limit] (the type of phi) is stricly less
than limit. The compiler can't decide what the result of that test
is. As optimizations proceed, the [init, limit] range could become
narrower as I understand and there's no risk for the compiler to
report the post loop as not taken.

I still believe it's risky to simply drop the OpaqueZeroTripGuard for
the post loop even if it can't constant fold at least because we
wouldn't want the zero trip guard to split thru phi.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298176](https://bugs.openjdk.org/browse/JDK-8298176): remove OpaqueZeroTripGuardPostLoop once main-loop disappears


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk20 pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/65.diff">https://git.openjdk.org/jdk20/pull/65.diff</a>

</details>
