### PR TITLE
JDK-8299156: Broken link in jdk.compiler/module-info.java

### DIFF
--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -65,7 +65,7 @@ import javax.tools.StandardLocation;
  * <h3>Options and Environment Variables</h3>
  *
  * The full set of options and environment variables supported by <em>javac</em>
- * is given in the <a href="../specs/man/javac.html"><em>javac Tool Guide</em></a>.
+ * is given in the <a href="../../specs/man/javac.html"><em>javac Tool Guide</em></a>.
  * However, there are some restrictions when the compiler is invoked through
  * its API.
  *


### PR DESCRIPTION
Please review a trivial documentation fix to fix a broken link.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299156](https://bugs.openjdk.org/browse/JDK-8299156): Broken link in jdk.compiler/module-info.java


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.org/jdk20 pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/67.diff">https://git.openjdk.org/jdk20/pull/67.diff</a>

</details>
