### PR TITLE
8299077: [REDO] JDK-4512626 Non-editable JTextArea provides no visual indication of keyboard focus

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -366,6 +366,8 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
         }
     }
 
+    private int savedBlinkRate = 0;
+    private boolean isBlinkRateSaved = false;
     // --- FocusListener methods --------------------------
 
     /**
@@ -379,8 +381,21 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
     public void focusGained(FocusEvent e) {
         if (component.isEnabled()) {
             if (component.isEditable()) {
-                setVisible(true);
+                if (isBlinkRateSaved) {
+                    setBlinkRate(savedBlinkRate);
+                    savedBlinkRate = 0;
+                    isBlinkRateSaved = false;
+                }
+            } else {
+                if (getBlinkRate() != 0) {
+                    if (!isBlinkRateSaved) {
+                        savedBlinkRate = getBlinkRate();
+                        isBlinkRateSaved = true;
+                    }
+                    setBlinkRate(0);
+                }
             }
+            setVisible(true);
             setSelectionVisible(true);
             updateSystemSelection();
         }
@@ -1031,16 +1046,30 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
      * @see Caret#setBlinkRate
      */
     public void setBlinkRate(int rate) {
+        if (rate < 0) {
+            throw new IllegalArgumentException("Invalid blink rate: " + rate);
+        }
         if (rate != 0) {
-            if (flasher == null) {
-                flasher = new Timer(rate, handler);
+            if (component.isEditable()) {
+                if (flasher == null) {
+                    flasher = new Timer(rate, handler);
+                }
+                flasher.setDelay(rate);
+            } else {
+                savedBlinkRate = rate;
+                isBlinkRateSaved = true;
             }
-            flasher.setDelay(rate);
         } else {
             if (flasher != null) {
                 flasher.stop();
                 flasher.removeActionListener(handler);
                 flasher = null;
+            }
+            if (component.isEditable()) {
+                if (isBlinkRateSaved) {
+                    savedBlinkRate = 0;
+                    isBlinkRateSaved = false;
+                }
             }
         }
     }
@@ -1053,6 +1082,9 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
      * @see Caret#getBlinkRate
      */
     public int getBlinkRate() {
+        if (isBlinkRateSaved) {
+            return savedBlinkRate;
+        }
         return (flasher == null) ? 0 : flasher.getDelay();
     }
 

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1065,11 +1065,9 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                 flasher.removeActionListener(handler);
                 flasher = null;
             }
-            if (component.isEditable()) {
-                if (isBlinkRateSaved) {
-                    savedBlinkRate = 0;
-                    isBlinkRateSaved = false;
-                }
+            if (component.isEditable() && isBlinkRateSaved) {
+                savedBlinkRate = 0;
+                isBlinkRateSaved = false;
             }
         }
     }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -657,8 +657,6 @@ javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
-javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 windows-all
-javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 linux-all
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all

--- a/test/jdk/javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java
+++ b/test/jdk/javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,17 @@
  * questions.
  */
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JTextField;
+import javax.swing.MenuSelectionManager;
+import javax.swing.SwingUtilities;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.event.InputEvent;
-import java.awt.image.BufferedImage;
 
 /**
  * @test
@@ -40,131 +47,113 @@ public class MultiSelectionTest {
     private static JTextField field1;
     private static JTextField field2;
     private static JFrame frame;
-    private static Rectangle bounds;
     private static JMenu menu;
     private static JTextField anotherWindow;
     private static Point menuLoc;
     private static JFrame frame2;
 
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(() -> {
-            frame = new JFrame();
-            field1 = new JTextField("field1                       ");
-            field2 = new JTextField("field2                       ");
-            field1.setEditable(false);
-            field2.setEditable(false);
-            frame.getContentPane().setLayout(new FlowLayout());
-            frame.getContentPane().add(field1);
-            frame.getContentPane().add(field2);
-            JMenuBar menuBar = new JMenuBar();
-            menu = new JMenu("menu");
-            menu.add(new JMenuItem("item"));
-            menuBar.add(menu);
-            frame.setJMenuBar(menuBar);
-            frame.pack();
-            frame.setVisible(true);
-        });
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                field1 = new JTextField("field1                       ");
+                field2 = new JTextField("field2                       ");
+                field1.setEditable(false);
+                field2.setEditable(false);
+                frame.getContentPane().setLayout(new FlowLayout());
+                frame.getContentPane().add(field1);
+                frame.getContentPane().add(field2);
+                JMenuBar menuBar = new JMenuBar();
+                menu = new JMenu("menu");
+                menu.add(new JMenuItem("item"));
+                menuBar.add(menu);
+                frame.setJMenuBar(menuBar);
+                frame.pack();
+                frame.setVisible(true);
+            });
 
-        Robot robot = new Robot();
-        robot.waitForIdle();
-        robot.delay(200);
-        SwingUtilities.invokeAndWait(() -> {
-            bounds = field2.getBounds();
-            bounds.setLocation(field2.getLocationOnScreen());
-        });
-        BufferedImage nosel = robot.createScreenCapture(bounds);
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(200);
 
-        SwingUtilities.invokeAndWait(field2::requestFocus);
-        SwingUtilities.invokeAndWait(field2::selectAll);
-        robot.waitForIdle();
-        robot.delay(200);
-        BufferedImage sel = robot.createScreenCapture(bounds);
+            SwingUtilities.invokeAndWait(field2::requestFocus);
+            SwingUtilities.invokeAndWait(field2::selectAll);
+            robot.waitForIdle();
+            robot.delay(200);
 
-        SwingUtilities.invokeAndWait(() -> {
-            menuLoc = menu.getLocationOnScreen();
-            menuLoc.translate(10, 10);
-        });
-        robot.mouseMove(menuLoc.x, menuLoc.y);
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        robot.delay(50);
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        robot.waitForIdle();
-        robot.delay(200);
-        if (!biEqual(robot.createScreenCapture(bounds), sel)) {
-            throw new RuntimeException("Test fails: menu hides selection");
-        }
-
-        SwingUtilities.invokeAndWait(
-                      MenuSelectionManager.defaultManager()::clearSelectedPath);
-        SwingUtilities.invokeAndWait(field1::requestFocus);
-        robot.waitForIdle();
-        robot.delay(200);
-        if (!biEqual(robot.createScreenCapture(bounds), sel)) {
-            throw new RuntimeException(
-                    "Test fails: focus lost hides single selection");
-        }
-
-        SwingUtilities.invokeAndWait(field1::selectAll);
-        robot.waitForIdle();
-        robot.delay(200);
-        if (!biEqual(robot.createScreenCapture(bounds), nosel)) {
-            throw new RuntimeException(
-                    "Test fails: focus lost doesn't hide selection upon multi selection");
-        }
-
-        SwingUtilities.invokeAndWait(field2::requestFocus);
-        robot.waitForIdle();
-        robot.delay(200);
-        if (!biEqual(robot.createScreenCapture(bounds), sel)) {
-            throw new RuntimeException(
-                    "Test fails: focus gain hides selection upon multi selection");
-        }
-
-        SwingUtilities.invokeAndWait(field2::requestFocus);
-        robot.waitForIdle();
-        SwingUtilities.invokeAndWait(() ->{
-            frame2 = new JFrame();
-            Point loc = frame.getLocationOnScreen();
-            loc.translate(0, frame.getHeight());
-            frame2.setLocation(loc);
-            anotherWindow = new JTextField("textField3");
-            frame2.add(anotherWindow);
-            frame2.pack();
-            frame2.setVisible(true);
-        });
-        robot.waitForIdle();
-        SwingUtilities.invokeAndWait(anotherWindow::requestFocus);
-        robot.waitForIdle();
-        robot.delay(200);
-        if (biEqual(robot.createScreenCapture(bounds), nosel)) {
-            throw new RuntimeException(
-                    "Test fails: switch window hides selection");
-        }
-
-        SwingUtilities.invokeAndWait(anotherWindow::selectAll);
-        robot.waitForIdle();
-        robot.delay(200);
-        if (biEqual(robot.createScreenCapture(bounds), sel)) {
-            throw new RuntimeException(
-                "Test fails: selection ownership is lost selection is shown");
-        }
-
-        SwingUtilities.invokeLater(frame2::dispose);
-        SwingUtilities.invokeLater(frame::dispose);
-    }
-
-    static boolean biEqual(BufferedImage i1, BufferedImage i2) {
-        if (i1.getWidth() == i2.getWidth() &&
-                                         i1.getHeight() == i2.getHeight()) {
-            for (int x = 0; x < i1.getWidth(); x++) {
-                for (int y = 0; y < i1.getHeight(); y++) {
-                    if (i1.getRGB(x, y) != i2.getRGB(x, y)) {
-                        return false;
-                    }
-                }
+            SwingUtilities.invokeAndWait(() -> {
+                menuLoc = menu.getLocationOnScreen();
+                menuLoc.translate(10, 10);
+            });
+            robot.mouseMove(menuLoc.x, menuLoc.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(50);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(200);
+            if (!field2.getCaret().isSelectionVisible()) {
+                throw new RuntimeException("Test fails: menu hides selection");
             }
-            return true;
+
+            SwingUtilities.invokeAndWait(
+                    MenuSelectionManager.defaultManager()::clearSelectedPath);
+            SwingUtilities.invokeAndWait(field1::requestFocus);
+            robot.waitForIdle();
+            robot.delay(200);
+            if (field2.getSelectedText() == null || field2.getSelectedText().length() == 0) {
+                throw new RuntimeException(
+                        "Test fails: focus lost hides single selection");
+            }
+
+            SwingUtilities.invokeAndWait(field1::selectAll);
+            robot.waitForIdle();
+            robot.delay(200);
+            if (field2.getCaret().isSelectionVisible()) {
+                throw new RuntimeException(
+                        "Test fails: focus lost doesn't hide selection upon multi selection");
+            }
+
+            SwingUtilities.invokeAndWait(field2::requestFocus);
+            robot.waitForIdle();
+            robot.delay(200);
+            if (!field2.getCaret().isSelectionVisible()) {
+                throw new RuntimeException(
+                        "Test fails: focus gain hides selection upon multi selection");
+            }
+
+            SwingUtilities.invokeAndWait(field2::requestFocus);
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(() -> {
+                frame2 = new JFrame();
+                Point loc = frame.getLocationOnScreen();
+                loc.translate(0, frame.getHeight());
+                frame2.setLocation(loc);
+                anotherWindow = new JTextField("textField3");
+                frame2.add(anotherWindow);
+                frame2.pack();
+                frame2.setVisible(true);
+            });
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(anotherWindow::requestFocus);
+            robot.waitForIdle();
+            robot.delay(200);
+            if (!field2.getCaret().isSelectionVisible()) {
+                throw new RuntimeException(
+                        "Test fails: switch window hides selection");
+            }
+
+            SwingUtilities.invokeAndWait(anotherWindow::selectAll);
+            robot.waitForIdle();
+            robot.delay(200);
+            if (field2.getCaret().isSelectionVisible()) {
+                throw new RuntimeException(
+                        "Test fails: selection ownership is lost selection is shown");
+            }
+        } finally {
+            if (frame2 != null) {
+                SwingUtilities.invokeLater(frame2::dispose);
+            }
+            SwingUtilities.invokeLater(frame::dispose);
         }
-        return false;
     }
 }


### PR DESCRIPTION
Slightly updated original fix - got rid of the extra flasher reset. Tests are fixed to be more stable and pass on the corresponding platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8299077](https://bugs.openjdk.org/browse/JDK-8299077): [REDO] JDK-4512626 Non-editable JTextArea provides no visual indication of keyboard focus
 * [JDK-8299127](https://bugs.openjdk.org/browse/JDK-8299127): [REDO] JDK-8194048 Regression automated test '/open/test/jdk/javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java' fails
 * [JDK-8299128](https://bugs.openjdk.org/browse/JDK-8299128): [REDO] JDK-8213562 Test javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java fails


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [e55fbbad](https://git.openjdk.org/jdk20/pull/68/files/e55fbbad8e39c6a1dd61b464b632a504807e695f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jdk20 pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/68.diff">https://git.openjdk.org/jdk20/pull/68.diff</a>

</details>
