### PR TITLE
8299227: host `exif.org` not found in link in doc comment

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
@@ -78,8 +78,8 @@ import javax.imageio.ImageWriteParam;
  * <tr>
  * <td>Exif JPEG</td>
  * <td>Exif-specific JPEG compression (see note following this table)</td>
- * <td><a href="https://www.kodak.com/global/plugins/acrobat/en/service/
- * digCam/exifStandard2.pdf">Exif 2.2 Specification</a>
+ * <td><a href="https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf">
+ * Exif 2.2 Specification</a>
  * (PDF), section 4.5.5, "Basic Structure of Thumbnail Data"</td>
  * </table>
  *

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,8 @@ import javax.imageio.ImageWriteParam;
  * <tr>
  * <td>Exif JPEG</td>
  * <td>Exif-specific JPEG compression (see note following this table)</td>
- * <td><a href="http://www.exif.org/Exif2-2.PDF">Exif 2.2 Specification</a>
+ * <td><a href="https://www.kodak.com/global/plugins/acrobat/en/service/
+ * digCam/exifStandard2.pdf">Exif 2.2 Specification</a>
  * (PDF), section 4.5.5, "Basic Structure of Thumbnail Data"</td>
  * </table>
  *

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriteParam.java
@@ -78,9 +78,9 @@ import javax.imageio.ImageWriteParam;
  * <tr>
  * <td>Exif JPEG</td>
  * <td>Exif-specific JPEG compression (see note following this table)</td>
- * <td><a href="https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf">
- * Exif 2.2 Specification</a>
- * (PDF), section 4.5.5, "Basic Structure of Thumbnail Data"</td>
+ * <td><a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">
+ * Exif 2.3 Specification</a>
+ * (PDF), section 4.5.8, "Basic Structure of Thumbnail Data"</td>
  * </table>
  *
  * <p>

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
@@ -574,9 +574,9 @@ DEFLATE Compressed Data Format Specification</a></td>
 <th scope="row">9</th>
 <td>Exif JPEG</td>
 <td>Exif-specific JPEG compression (see note following this table)</td>
-<td><a href="https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf">
-    Exif 2.2 Specification</a>
-(PDF), section 4.5.5, "Basic Structure of Thumbnail Data"</td>
+<td><a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">
+    Exif 2.3 Specification</a>
+(PDF), section 4.5.8, "Basic Structure of Thumbnail Data"</td>
 </tbody>
 </table>
 
@@ -740,7 +740,7 @@ color space is grayscale.</li>
 be written as supplied.</p>
 
 <p>If an Exif image is being written, the set of fields present and their
-values will be modified such that the result is in accord with the Exif 2.2
+values will be modified such that the result is in accord with the Exif 2.3
 specification.</p>
 
 <p>Setting up the image metadata to write to a TIFF stream may be simplified

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
@@ -5,7 +5,7 @@
     <title>TIFF Metadata Format Specification and Usage Notes</title>
 </head>
 <!--
-Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -574,7 +574,8 @@ DEFLATE Compressed Data Format Specification</a></td>
 <th scope="row">9</th>
 <td>Exif JPEG</td>
 <td>Exif-specific JPEG compression (see note following this table)</td>
-<td><a href="http://www.exif.org/Exif2-2.PDF">Exif 2.2 Specification</a>
+<td><a href="https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf">
+    Exif 2.2 Specification</a>
 (PDF), section 4.5.5, "Basic Structure of Thumbnail Data"</td>
 </tbody>
 </table>

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1614,8 +1614,8 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_setSource
 /*
  * For EXIF images, the APP1 will appear immediately after the SOI,
  * so it's safe to only look at the first marker in the list.
- * (see https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf,
- * section 4.7, page 58)
+ * (see https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf,
+ * section 4.7, page 83)
  */
 #define IS_EXIF(c) \
     (((c)->marker_list != NULL) && ((c)->marker_list->marker == JPEG_APP1))
@@ -1716,8 +1716,8 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_readImageHeader
              *  - we got JFIF image
              *     Must be YCbCr (see http://www.w3.org/Graphics/JPEG/jfif3.pdf, page 2)
              *  - we got EXIF image
-             *     Must be YCbCr (see https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf,
-             *     section 4.7, page 63)
+             *     Must be YCbCr (see https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf,
+             *     section 4.7, page 88)
              *  - something else
              *     Apply heuristical rules to identify actual colorspace.
              */

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1614,8 +1614,8 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_setSource
 /*
  * For EXIF images, the APP1 will appear immediately after the SOI,
  * so it's safe to only look at the first marker in the list.
- * (see https://www.kodak.com/global/plugins/acrobat/en/
- * service/digCam/exifStandard2.pdf, section 4.7, page 58)
+ * (see https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf,
+ * section 4.7, page 58)
  */
 #define IS_EXIF(c) \
     (((c)->marker_list != NULL) && ((c)->marker_list->marker == JPEG_APP1))
@@ -1716,8 +1716,8 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_readImageHeader
              *  - we got JFIF image
              *     Must be YCbCr (see http://www.w3.org/Graphics/JPEG/jfif3.pdf, page 2)
              *  - we got EXIF image
-             *     Must be YCbCr (see https://www.kodak.com/global/plugins/acrobat/en/
-             *      service/digCam/exifStandard2.pdf, section 4.7, page 63)
+             *     Must be YCbCr (see https://www.kodak.com/global/plugins/acrobat/en/service/digCam/exifStandard2.pdf,
+             *     section 4.7, page 63)
              *  - something else
              *     Apply heuristical rules to identify actual colorspace.
              */

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1614,7 +1614,8 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_setSource
 /*
  * For EXIF images, the APP1 will appear immediately after the SOI,
  * so it's safe to only look at the first marker in the list.
- * (see http://www.exif.org/Exif2-2.PDF, section 4.7, page 58)
+ * (see https://www.kodak.com/global/plugins/acrobat/en/
+ * service/digCam/exifStandard2.pdf, section 4.7, page 58)
  */
 #define IS_EXIF(c) \
     (((c)->marker_list != NULL) && ((c)->marker_list->marker == JPEG_APP1))
@@ -1715,7 +1716,8 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageReader_readImageHeader
              *  - we got JFIF image
              *     Must be YCbCr (see http://www.w3.org/Graphics/JPEG/jfif3.pdf, page 2)
              *  - we got EXIF image
-             *     Must be YCbCr (see http://www.exif.org/Exif2-2.PDF, section 4.7, page 63)
+             *     Must be YCbCr (see https://www.kodak.com/global/plugins/acrobat/en/
+             *      service/digCam/exifStandard2.pdf, section 4.7, page 63)
              *  - something else
              *     Apply heuristical rules to identify actual colorspace.
              */


### PR DESCRIPTION
Reported broken links are updated accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299227](https://bugs.openjdk.org/browse/JDK-8299227): host `exif.org` not found in link in doc comment


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jdk20 pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/74.diff">https://git.openjdk.org/jdk20/pull/74.diff</a>

</details>
