### PR TITLE
8299241: jdk/jfr/api/consumer/streaming/TestJVMCrash.java generates unnecessary core file

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class TestJVMCrash {
     public static void main(String... args) throws Exception  {
         int id = 1;
         while (true) {
-            try (TestProcess process = new TestProcess("crash-application-" + id++))  {
+            try (TestProcess process = new TestProcess("crash-application-" + id++, false /* createCore */))  {
                 AtomicInteger eventCounter = new AtomicInteger();
                 try (EventStream es = EventStream.openRepository(process.getRepository())) {
                     // Start from first event in repository

--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestProcess.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,11 +54,16 @@ public final class TestProcess implements AutoCloseable {
     private final Path path;
 
     public TestProcess(String name) throws IOException {
+        this(name, true /* createCore */);
+    }
+
+    public TestProcess(String name, boolean createCore) throws IOException {
         this.path = Paths.get("action-" + System.currentTimeMillis()).toAbsolutePath();
         String[] args = {
                 "--add-exports",
                 "java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-XX:StartFlightRecording:settings=none",
+                "-XX:" + (createCore ? "+" : "-") + "CreateCoredumpOnCrash",
                 TestProcess.class.getName(), path.toString()
             };
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);


### PR DESCRIPTION
A trivial fix to keep jdk/jfr/api/consumer/streaming/TestJVMCrash.java from generating
an unnecessary core file.

Ran TestJVMCrash.java on 10 configs in Mach5: linux-aarch64, linux-aarch64-debug,
linux-x64, linux-x64-debug, macosx-aarch64, macosx-aarch64-debug, macosx-x64,
macosx-x64-debug, windows-x64, and windows-x64-debug. All 10 .jtr files reported:

    CreateCoredumpOnCrash turned off, no core file dumped

Also ran the open ":jdk_jfr" and closed JFR tests on all 10 platforms. No failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299241](https://bugs.openjdk.org/browse/JDK-8299241): jdk/jfr/api/consumer/streaming/TestJVMCrash.java generates unnecessary core file


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/jdk20 pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/75.diff">https://git.openjdk.org/jdk20/pull/75.diff</a>

</details>
