### PR TITLE
8298592: Add java man page documentation for ChaCha20 and Poly1305 intrinsics

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -2524,6 +2524,22 @@ instructions.
 Flags that control intrinsics now require the option
 \f[V]-XX:+UnlockDiagnosticVMOptions\f[R].
 .TP
+-XX:+UseChaCha20Intrinsics
+Enable ChaCha20 intrinsics.
+This option is on by default for supported platforms.
+To disable ChaCha20 intrinsics, specify
+\f[V]-XX:-UseChaCha20Intrinsics\f[R].
+Flags that control intrinsics now require the option
+\f[V]-XX:+UnlockDiagnosticVMOptions\f[R].
+.TP
+-XX:+UsePoly1305Intrinsics
+Enable Poly1305 intrinsics.
+This option is on by default for supported platforms.
+To disable Poly1305 intrinsics, specify
+\f[V]-XX:-UsePoly1305Intrinsics\f[R].
+Flags that control intrinsics now require the option
+\f[V]-XX:+UnlockDiagnosticVMOptions\f[R].
+.TP
 \f[V]-XX:+UseBASE64Intrinsics\f[R]
 Controls the use of accelerated BASE64 encoding routines for
 \f[V]java.util.Base64\f[R].

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -2524,7 +2524,7 @@ instructions.
 Flags that control intrinsics now require the option
 \f[V]-XX:+UnlockDiagnosticVMOptions\f[R].
 .TP
--XX:+UseChaCha20Intrinsics
+\f[V]-XX:+UseChaCha20Intrinsics\f[R]
 Enable ChaCha20 intrinsics.
 This option is on by default for supported platforms.
 To disable ChaCha20 intrinsics, specify
@@ -2532,7 +2532,7 @@ To disable ChaCha20 intrinsics, specify
 Flags that control intrinsics now require the option
 \f[V]-XX:+UnlockDiagnosticVMOptions\f[R].
 .TP
--XX:+UsePoly1305Intrinsics
+\f[V]-XX:+UsePoly1305Intrinsics\f[R]
 Enable Poly1305 intrinsics.
 This option is on by default for supported platforms.
 To disable Poly1305 intrinsics, specify


### PR DESCRIPTION
This adds documentation to the `java(1)` man page for new ChaCha20 and Poly1305 intrinsics, highlighting the diagnostic flags that were delivered in those feature enhancements.  This is similar to what has already been done for AES and GHASH diagnostic flags.

- JBS: https://bugs.openjdk.org/browse/JDK-8298592
- Flags were delivered in ( openjdk/jdk#7702 for ChaCha20 and openjdk/jdk#10582 for Poly1305, with a minor change to the Poly1305 flag name in #49 )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298592](https://bugs.openjdk.org/browse/JDK-8298592): Add java man page documentation for ChaCha20 and Poly1305 intrinsics


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/jdk20 pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/78.diff">https://git.openjdk.org/jdk20/pull/78.diff</a>

</details>
