### PR TITLE
8299476: PPC64 Zero build fails after JDK-8286302

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -483,8 +483,11 @@ FreezeBase::FreezeBase(JavaThread* thread, ContinuationWrapper& cont, intptr_t* 
 
   assert(_cont.chunk_invariant(), "");
   assert(!Interpreter::contains(_cont.entryPC()), "");
-  static const int doYield_stub_frame_size = NOT_PPC64(frame::metadata_words)
-                                             PPC64_ONLY(frame::abi_reg_args_size >> LogBytesPerWord);
+#if !defined(PPC64) || defined(ZERO)
+  static const int doYield_stub_frame_size = frame::metadata_words;
+#else
+  static const int doYield_stub_frame_size = frame::abi_reg_args_size >> LogBytesPerWord;
+#endif
   assert(SharedRuntime::cont_doYield_stub()->frame_size() == doYield_stub_frame_size, "");
 
   // properties of the continuation on the stack; all sizes are in words


### PR DESCRIPTION
Zero does not have access to PPC64-specific constants, so this happens:

```
/home/shade/trunks/shipilev-jdk20/src/hotspot/share/runtime/continuationFreezeThaw.cpp: In constructor 'FreezeBase::FreezeBase(JavaThread*, ContinuationWrapper&, intptr_t*)':
/home/shade/trunks/shipilev-jdk20/src/hotspot/share/runtime/continuationFreezeThaw.cpp:487:64: error: 'abi_reg_args_size' is not a member of 'frame'
  487 | PPC64_ONLY(frame::abi_reg_args_size >> LogBytesPerWord);
      | ^~~~~~~~~~~~~~~~~
``` 

Testing:
 - [x] Linux x86_64 {server, zero} compilation
 - [x] Linux PPC64 {server, zero} cross-compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299476](https://bugs.openjdk.org/browse/JDK-8299476): PPC64 Zero build fails after JDK-8286302


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk20 pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/79.diff">https://git.openjdk.org/jdk20/pull/79.diff</a>

</details>
