### PR TITLE
8299561: VaList.empty() doesn't return a list associated with the global scope

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -129,7 +129,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
     }
 
     private static MemorySegment emptyListAddress() {
-        MemorySegment ms = MemorySegment.allocateNative(LAYOUT, SegmentScope.auto());
+        MemorySegment ms = MemorySegment.allocateNative(LAYOUT, SegmentScope.global());
         VH_stack.set(ms, MemorySegment.NULL);
         VH_gr_top.set(ms, MemorySegment.NULL);
         VH_vr_top.set(ms, MemorySegment.NULL);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -138,7 +138,7 @@ public non-sealed class SysVVaList implements VaList {
     }
 
     private static MemorySegment emptyListAddress() {
-        MemorySegment base = MemorySegment.allocateNative(LAYOUT, SegmentScope.auto());
+        MemorySegment base = MemorySegment.allocateNative(LAYOUT, SegmentScope.global());
         VH_gp_offset.set(base, MAX_GP_OFFSET);
         VH_fp_offset.set(base, MAX_FP_OFFSET);
         VH_overflow_arg_area.set(base, MemorySegment.NULL);

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -907,4 +907,8 @@ public class VaListTest extends NativeTestHelper {
         assertThrows(NoSuchElementException.class, () -> nextVarg(vaList, next));
     }
 
+    @Test(dataProvider = "emptyVaLists")
+    public void testEmptyVaListScope(VaList vaList) {
+        assertEquals(vaList.segment().scope(), SegmentScope.global());
+    }
 }


### PR DESCRIPTION
This patch fixes a long-standing conformance issue: `VaList.empty` is specified to return a `VaList` associated with the global scope, but in some platforms (Aarch64/Linux and x64/Linux) the empty list is associated with an implicit scope instead.

This doesn't make a lot of difference, given that the empty list is always stored in a static final in the underlying implementation - that said, it would be a good thing to rectify this conformance issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299561](https://bugs.openjdk.org/browse/JDK-8299561): VaList.empty() doesn't return a list associated with the global scope


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jdk20 pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/82.diff">https://git.openjdk.org/jdk20/pull/82.diff</a>

</details>
