### PR TITLE
8299528: IR test: TestEor3AArch64.java fails on aarch64

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1197,6 +1197,16 @@ public class IRNode {
     public static final String XOR_V_MASK = PREFIX + "XOR_V_MASK" + POSTFIX;
     static {
         beforeMatchingNameRegex(XOR_V_MASK, "XorVMask");
+    }
+
+    public static final String XOR3_NEON = PREFIX + "XOR3_NEON" + POSTFIX;
+    static {
+        machOnlyNameRegex(XOR3_NEON, "veor3_neon");
+    }
+
+    public static final String XOR3_SVE = PREFIX + "XOR3_SVE" + POSTFIX;
+    static {
+        machOnlyNameRegex(XOR3_SVE, "veor3_sve");
     }
 
     /*

--- a/test/hotspot/jtreg/compiler/vectorization/TestEor3AArch64.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestEor3AArch64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,8 +78,8 @@ public class TestEor3AArch64 {
 
     // Test for eor3 Neon and SVE2 instruction for integers
     @Test
-    @IR(counts = {"veor3_neon", "> 0"}, applyIf = {"MaxVectorSize", "16"}, applyIfCPUFeature = {"sha3", "true"})
-    @IR(counts = {"veor3_sve", "> 0"}, applyIfAnd = {"UseSVE", "2", "MaxVectorSize", "> 16"})
+    @IR(counts = {IRNode.XOR3_NEON, "> 0"}, applyIf = {"MaxVectorSize", "16"}, applyIfCPUFeature = {"sha3", "true"})
+    @IR(counts = {IRNode.XOR3_SVE, "> 0"}, applyIfAnd = {"UseSVE", "2", "MaxVectorSize", "> 16"})
     public static void testIntEor3() {
         for (int i = 0; i < LENGTH; i++) {
             ir[i] = ia[i] ^ ib[i] ^ ic[i];
@@ -96,8 +96,8 @@ public class TestEor3AArch64 {
 
     // Test for eor3 Neon and SVE2 instruction for longs
     @Test
-    @IR(counts = {"veor3_neon", "> 0"}, applyIf = {"MaxVectorSize", "16"}, applyIfCPUFeature = {"sha3", "true"})
-    @IR(counts = {"veor3_sve", "> 0"}, applyIfAnd = {"UseSVE", "2", "MaxVectorSize", "> 16"})
+    @IR(counts = {IRNode.XOR3_NEON, "> 0"}, applyIf = {"MaxVectorSize", "16"}, applyIfCPUFeature = {"sha3", "true"})
+    @IR(counts = {IRNode.XOR3_SVE, "> 0"}, applyIfAnd = {"UseSVE", "2", "MaxVectorSize", "> 16"})
     public static void testLongEor3() {
         for (int i = 0; i < LENGTH; i++) {
             lr[i] = la[i] ^ lb[i] ^ lc[i];


### PR DESCRIPTION
The IR test - TestEor3AArch64.java fails during IR verification as the IR nodes to be matched have not been updated to the newer IR framework introduced in the JDK source with this PR -
https://github.com/openjdk/jdk/pull/10695.

This patch updates the relevant IR nodes in the tests accordingly.

The test passes successfully on -
1. an aarch64 machine with vector size of 128-bit that supports the Neon eor3 instruction
2. an aarch64 simulator with vector size of 256-bit that supports the SVE2 feature which includes the SVE2 eor3 instruction.
Generation of IR Nodes - XOR3_NEON and XOR3_SVE have thus been verified on the above mentioned machines.

This is a trivial patch related to a test and has minimal impact with low risk and maybe considered to be merged with JDK20 in RDP1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299528](https://bugs.openjdk.org/browse/JDK-8299528): IR test: TestEor3AArch64.java fails on aarch64


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.org/jdk20 pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/83.diff">https://git.openjdk.org/jdk20/pull/83.diff</a>

</details>
