### PR TITLE
8298525: javadoc crashes with "UnsupportedOperationException: Not yet implemented" in SeeTaglet.inherit

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import com.sun.source.doctree.SeeTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import jdk.javadoc.internal.doclets.toolkit.Content;
+import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFinder.Result;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
@@ -51,7 +52,10 @@ public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
 
     @Override
     public Output inherit(Element owner, DocTree tag, boolean isFirstSentence, BaseConfiguration configuration) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        CommentHelper ch = configuration.utils.getCommentHelper(owner);
+        var path = ch.getDocTreePath(tag);
+        configuration.getMessages().warning(path, "doclet.inheritDocWithinInappropriateTag");
+        return new Output(null, null, List.of(), true /* true, otherwise there will be an exception up the stack */);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SpecTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SpecTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import com.sun.source.doctree.SpecTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import jdk.javadoc.internal.doclets.toolkit.Content;
+import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFinder.Result;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
@@ -50,7 +51,10 @@ public class SpecTaglet extends BaseTaglet implements InheritableTaglet {
 
     @Override
     public Output inherit(Element owner, DocTree tag, boolean isFirstSentence, BaseConfiguration configuration) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        CommentHelper ch = configuration.utils.getCommentHelper(owner);
+        var path = ch.getDocTreePath(tag);
+        configuration.getMessages().warning(path, "doclet.inheritDocWithinInappropriateTag");
+        return new Output(null, null, List.of(), true /* true, otherwise there will be an exception up the stack */);
     }
 
     @Override

--- a/test/langtools/jdk/javadoc/doclet/testInheritDocWithinInappropriateTag/TestInheritDocWithinInappropriateTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testInheritDocWithinInappropriateTag/TestInheritDocWithinInappropriateTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8284299 8287379
+ * @bug 8284299 8287379 8298525
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
  * @build toolbox.ToolBox javadoc.tester.*
@@ -65,6 +65,9 @@ public class TestInheritDocWithinInappropriateTag extends JavadocTester {
                              * {@linkplain Object#hashCode() {@inheritDoc}}
                              *
                              * {@index term {@inheritDoc}}
+                             *
+                             * @see A {@inheritDoc}
+                             * @spec http://example.com {@inheritDoc}
                              */
                             @Override
                             public void x() { }
@@ -94,6 +97,16 @@ public class TestInheritDocWithinInappropriateTag extends JavadocTester {
                 """
                         warning: @inheritDoc cannot be used within this tag
                              * {@index term {@inheritDoc}}
+                               ^
+                        """,
+                """
+                        warning: @inheritDoc cannot be used within this tag
+                             * @see A {@inheritDoc}
+                               ^
+                        """,
+                """
+                        warning: @inheritDoc cannot be used within this tag
+                             * @spec http://example.com {@inheritDoc}
                                ^
                         """);
     }


### PR DESCRIPTION
This makes JavaDoc warn, not crash, if `{@inheritDoc}` appears in the `@see` tag and the newer `@spec` tag. This is a jurry-rigged patch to fix an infrequent and erroneous case that should be properly revisited later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298525](https://bugs.openjdk.org/browse/JDK-8298525): javadoc crashes with "UnsupportedOperationException: Not yet implemented" in SeeTaglet.inherit


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.org/jdk20 pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/84.diff">https://git.openjdk.org/jdk20/pull/84.diff</a>

</details>
