### PR TITLE
8294744: AArch64: applications/kitchensink/Kitchensink.java crashed: assert(oopDesc::is_oop(obj)) failed: not an oop

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -836,9 +836,12 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     __ stp(r10, rscratch1, Address(sp, 4 * wordSize));
     // Move SP out of the way
     __ mov(sp, rscratch1);
-    } else {
-    __ mov(rscratch1, sp);
+  } else {
+    // Make sure there is room for the exception oop pushed in case method throws
+    // an exception (see TemplateInterpreterGenerator::generate_throw_exception())
+    __ sub(rscratch1, sp, 2 * wordSize);
     __ stp(zr, rscratch1, Address(sp, 4 * wordSize));
+    __ mov(sp, rscratch1);
   }
 }
 

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -776,8 +776,12 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     // Move SP out of the way
     __ mv(sp, t0);
   } else {
-    __ sd(sp, Address(sp, 5 * wordSize));
+    // Make sure there is room for the exception oop pushed in case method throws
+    // an exception (see TemplateInterpreterGenerator::generate_throw_exception())
+    __ sub(t0, sp, 2 * wordSize);
+    __ sd(t0, Address(sp, 5 * wordSize));
     __ sd(zr, Address(sp, 4 * wordSize));
+    __ mv(sp, t0);
   }
 }
 


### PR DESCRIPTION
Please review the following patch. The value we set initially for extended_sp on natives frames doesn't account for the oop that could be pushed to the stack in case the method throws an exception. This can create a situation in Interpreter::_throw_exception_entry where we push an exception oop to the Java expression stack below the actual physical stack pointer. When JFR is present though a JavaThread could receive a suspend signal right after that push. On Linux aarch64, because there is no red zone defined (nor implemented it seems), the pushed oop gets overwritten during the setup and execution of the signal handler. This later leads to a crash when popping the oop back and rethrowing in the caller of the native method. There are more details in the bug comments.

To fix it I used the same technique we use for normal Java frames, i.e. add extra space to extended_sp when creating the frame to account for the max space needed.

  I tested the patch by running Kitchensink.java around 150 times on mach5 with no failures (without the patch 50 runs would already show ~10 failures on average). I also run tiers1-6 for sanity check.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294744](https://bugs.openjdk.org/browse/JDK-8294744): AArch64: applications/kitchensink/Kitchensink.java crashed: assert(oopDesc::is_oop(obj)) failed: not an oop


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [2aeadb14](https://git.openjdk.org/jdk20/pull/85/files/2aeadb1445886dfca95665defdc095057d7af359)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/jdk20 pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/85.diff">https://git.openjdk.org/jdk20/pull/85.diff</a>

</details>
