### PR TITLE
8299740: CaptureCallState is missing @Preview annotation

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -345,6 +345,7 @@ public sealed interface Linker permits AbstractLinker {
          * }
          * }
          */
+        @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
         sealed interface CaptureCallState extends Option
                                           permits LinkerOptions.CaptureCallStateImpl {
             /**


### PR DESCRIPTION
This patch adds `@Preview` to the CaptureCallState interface.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299740](https://bugs.openjdk.org/browse/JDK-8299740): CaptureCallState is missing @Preview annotation


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jdk20 pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/86.diff">https://git.openjdk.org/jdk20/pull/86.diff</a>

</details>
