### PR TITLE
8299733: AArch64: "unexpected literal addressing mode" assertion failure with -XX:+PrintC1Statistics

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -505,7 +505,13 @@ class Address {
   }
 
   bool uses(Register reg) const {
-    return base() == reg || index() == reg;
+    switch (_mode) {
+    case literal:
+    case no_mode:
+      return false;
+    default:
+      return base() == reg || index() == reg;
+    }
   }
 
   address target() const {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -509,8 +509,15 @@ class Address {
     case literal:
     case no_mode:
       return false;
-    default:
+    case base_plus_offset:
+    case base_plus_offset_reg:
+    case pre:
+    case post:
+    case post_reg:
       return base() == reg || index() == reg;
+    default:
+      ShouldNotReachHere();
+      return false;
     }
   }
 

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -38,5 +38,3 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java 8288430 generic-all
 
 gc/cslocker/TestCSLocker.java 8293289 generic-x64
-
-compiler/c1/TestPrintC1Statistics.java 8298053 linux-aarch64


### PR DESCRIPTION
`MacroAssembler::incrementw()` asserts that

```
assert(!dst.uses(rscratch1), "invalid dst for address increment");
```

But `Address::uses()` can only be called on non-literal addresses.  We could change this assert to check `dst.getMode()` first but it seems cleaner to make `Address::uses()` handle the non-literal case.

This failure is trivial to reproduce with:

```
$ java -XX:+PrintC1Statistics -XX:+UseZGC --version
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299733](https://bugs.openjdk.org/browse/JDK-8299733): AArch64: "unexpected literal addressing mode" assertion failure with -XX:+PrintC1Statistics


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [b319405a](https://git.openjdk.org/jdk20/pull/87/files/b319405ae901450289c8d50fafa311863b9a16a1)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Contributors
 * Ningsheng Jian `<njian@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.org/jdk20 pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/87.diff">https://git.openjdk.org/jdk20/pull/87.diff</a>

</details>
