### PR TITLE
8299689: Make use of JLine for Console as "opt-in"

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -608,7 +608,13 @@ public class Console implements Flushable
     @SuppressWarnings("removal")
     private static Console instantiateConsole(boolean istty) {
         try {
-            // Try loading providers
+            /*
+             * The JdkConsole provider used for Console instantiation can be specified
+             * with the system property "jdk.console", whose value designates the module
+             * name of the implementation, and which defaults to "java.base". If no
+             * providers are available, or instantiation failed, java.base built-in
+             * Console implementation is used.
+             */
             PrivilegedAction<Console> pa = () -> {
                 var consModName = System.getProperty("jdk.console",
                         JdkConsoleProvider.DEFAULT_PROVIDER_MODULE_NAME);

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleProvider.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.nio.charset.Charset;
  * The provider used for instantiating JdkConsole instance can be
  * specified with the system property "jdk.console", whose value
  * designates the module name of the implementation, and which defaults
- * to "jdk.internal.le" (jline). If no providers is available,
+ * to "java.base". If no providers is available,
  * or instantiation failed, java.base built-in Console implementation
  * is used.
  */
@@ -39,7 +39,7 @@ public interface JdkConsoleProvider {
     /**
      * The module name of the JdkConsole default provider.
      */
-    String DEFAULT_PROVIDER_MODULE_NAME = "jdk.internal.le";
+    String DEFAULT_PROVIDER_MODULE_NAME = "java.base";
 
     /**
      * {@return the Console instance, or {@code null} if not available}

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleProvider.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleProvider.java
@@ -28,12 +28,6 @@ import java.nio.charset.Charset;
 
 /**
  * Service provider interface for JdkConsole implementations.
- * The provider used for instantiating JdkConsole instance can be
- * specified with the system property "jdk.console", whose value
- * designates the module name of the implementation, and which defaults
- * to "java.base". If no providers is available,
- * or instantiation failed, java.base built-in Console implementation
- * is used.
  */
 public interface JdkConsoleProvider {
     /**

--- a/test/jdk/java/io/Console/ModuleSelectionTest.java
+++ b/test/jdk/java/io/Console/ModuleSelectionTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8295803 8299137
+ * @bug 8295803 8299689
  * @summary Tests System.console() returns correct Console (or null) from the expected
  *          module.
  * @modules java.base/java.io:+open

--- a/test/jdk/java/io/Console/ModuleSelectionTest.java
+++ b/test/jdk/java/io/Console/ModuleSelectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,11 @@
 
 /**
  * @test
- * @bug 8295803
+ * @bug 8295803 8299137
  * @summary Tests System.console() returns correct Console (or null) from the expected
  *          module.
  * @modules java.base/java.io:+open
- * @run main/othervm ModuleSelectionTest jdk.internal.le
+ * @run main/othervm ModuleSelectionTest java.base
  * @run main/othervm -Djdk.console=jdk.internal.le ModuleSelectionTest jdk.internal.le
  * @run main/othervm -Djdk.console=java.base ModuleSelectionTest java.base
  * @run main/othervm --limit-modules java.base ModuleSelectionTest java.base

--- a/test/jdk/java/io/Console/RedirectTest.java
+++ b/test/jdk/java/io/Console/RedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/io/Console/RedirectTest.java
+++ b/test/jdk/java/io/Console/RedirectTest.java
@@ -28,7 +28,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
- * @bug 8295803 8299137
+ * @bug 8295803 8299689
  * @summary Tests System.console() works with standard input redirection.
  * @library /test/lib
  * @run main RedirectTest


### PR DESCRIPTION
Due to the fact that JLine spawns native processes to obtain terminal information on macOS/Linux, we decided to disable the JLine by default for performance degradation reasons. It is still possible to enable it by specifying it on the command line with `jdk.console` system property (not a public one though). Once we have a solution to avoid spawning processes, JLine may be back for use in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8299689](https://bugs.openjdk.org/browse/JDK-8299689): Make use of JLine for Console as "opt-in"
 * [JDK-8299690](https://bugs.openjdk.org/browse/JDK-8299690): Make use of JLine for Console as "opt-in" (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [b15a8bda](https://git.openjdk.org/jdk20/pull/88/files/b15a8bda116b6b6fe6ccd05242a0fb9b36643a49)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/jdk20 pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/88.diff">https://git.openjdk.org/jdk20/pull/88.diff</a>

</details>
