### PR TITLE
8299715: IR test: VectorGatherScatterTest.java fails with SVE randomly

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/VectorGatherScatterTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorGatherScatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public class VectorGatherScatterTest {
             ia[i] = i;
             la[i] = RD.nextLong(25);
             da[i] = RD.nextDouble(25.0);
-            m[i] = RD.nextBoolean();
+            m[i] = i % 2 == 0;
         }
     }
 
@@ -102,6 +102,8 @@ public class VectorGatherScatterTest {
     @IR(counts = { IRNode.LOAD_VECTOR_GATHER_MASKED, ">= 1" })
     public static void testLoadGatherMasked() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
+        // "mask" is guaranteed to be not alltrue, in case the masked
+        // gather load is optimized to the non-masked version.
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0, ia, 0, mask);
         av.intoArray(lr, 0);
         IntVector bv = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -132,6 +134,8 @@ public class VectorGatherScatterTest {
     public static void testStoreScatterMasked() {
         VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
         DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        // "mask" is guaranteed to be not alltrue, in case the masked
+        // scatter store is optimized to the non-masked version.
         av.intoArray(dr, 0, ia, 0, mask);
         IntVector bv = IntVector.fromArray(I_SPECIES, ia, 0);
         bv.add(0).intoArray(ir, 0);


### PR DESCRIPTION
The IR check fails randomly on two unit tests: `"testLoadGatherMasked"`
and `"testStoreScatterMasked"`. The two tests call the vector mask
controlled load_gather/store_scatter vector APIs, and the compiler
will generate the` "LoadVectorGatherMasked"`/`"StoreVectorScatterMasked"`
IR normally if the corresponding API is intrinsified successfully.
So for normal cases, the following IR check can success:

```
  @IR(counts = { IRNode.LOAD_VECTOR_GATHER_MASKED, ">= 1" })
```

But if all the lane values in the vector mask are true, the masked
API will be implemented with the corresponding un-masked API instead
(see the masked load gather API implementation [1]). And the C2 compiler
generates the un-masked IRs, i.e. `"LoadVectorGather"`/`"StoreVectorScatter"`.
For such cases, the above IR check will fail.

To make sure the masked load_gather/store_scatter IR is generated by
C2 compiler, we have to modify the mask input in the test to make sure
the vector mask is not alltrue.

[1] https://github.com/openjdk/jdk/blob/master/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java#L2931

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299715](https://bugs.openjdk.org/browse/JDK-8299715): IR test: VectorGatherScatterTest.java fails with SVE randomly


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jdk20 pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/90.diff">https://git.openjdk.org/jdk20/pull/90.diff</a>

</details>
