### PR TITLE
8299090: Specify coordinate order for additional CaptureCallState parameters on class as well

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -303,7 +303,7 @@ public sealed interface Linker permits AbstractLinker {
          *          before it can be overwritten by the Java runtime, or read through conventional means}
          * <p>
          * A downcall method handle linked with this option will feature an additional {@link MemorySegment}
-         * parameter directly following the target address, and optional SegmentAllocator parameters.
+         * parameter directly following the target address, and optional {@link SegmentAllocator} parameters.
          * This memory segment must be a native segment into which the captured state is written.
          *
          * @param capturedState the names of the values to save.
@@ -325,7 +325,7 @@ public sealed interface Linker permits AbstractLinker {
          * to a native segment provided by the user to the downcall method handle.
          * For this purpose, a downcall method handle linked with the {@link #captureCallState(String[])}
          * option will feature an additional {@link MemorySegment} parameter directly
-         * following the target address, and optional SegmentAllocator parameters.
+         * following the target address, and optional {@link SegmentAllocator} parameters.
          * This parameter represents the native segment into which the captured state is written.
          * <p>
          * The native segment should have the layout {@linkplain CaptureCallState#layout associated}

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -323,6 +323,10 @@ public sealed interface Linker permits AbstractLinker {
          * <p>
          * Execution state is captured by a downcall method handle on invocation, by writing it
          * to a native segment provided by the user to the downcall method handle.
+         * For this purpose, a downcall method handle linked with the {@link #captureCallState(String[])}
+         * option will feature an additional {@link MemorySegment} parameter directly
+         * following the target address parameter. This parameter represents the native segment
+         * into which the captured state is written.
          * <p>
          * The native segment should have the layout {@linkplain CaptureCallState#layout associated}
          * with the particular {@code CaptureCallState} instance used to link the downcall handle.

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -303,8 +303,8 @@ public sealed interface Linker permits AbstractLinker {
          *          before it can be overwritten by the Java runtime, or read through conventional means}
          * <p>
          * A downcall method handle linked with this option will feature an additional {@link MemorySegment}
-         * parameter directly following the target address parameter. This memory segment must be a
-         * native segment into which the captured state is written.
+         * parameter directly following the target address, and optional SegmentAllocator parameters.
+         * This memory segment must be a native segment into which the captured state is written.
          *
          * @param capturedState the names of the values to save.
          * @see CaptureCallState#supported()
@@ -325,8 +325,8 @@ public sealed interface Linker permits AbstractLinker {
          * to a native segment provided by the user to the downcall method handle.
          * For this purpose, a downcall method handle linked with the {@link #captureCallState(String[])}
          * option will feature an additional {@link MemorySegment} parameter directly
-         * following the target address parameter. This parameter represents the native segment
-         * into which the captured state is written.
+         * following the target address, and optional SegmentAllocator parameters.
+         * This parameter represents the native segment into which the captured state is written.
          * <p>
          * The native segment should have the layout {@linkplain CaptureCallState#layout associated}
          * with the particular {@code CaptureCallState} instance used to link the downcall handle.


### PR DESCRIPTION
A small doc clarification that also specifies where the additional MemorySegment parameter of a downcall method handle linked with the captureCallState option appears in the parameter list, on the CaptureCallState class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8299090](https://bugs.openjdk.org/browse/JDK-8299090): Specify coordinate order for additional CaptureCallState parameters on class as well
 * [JDK-8299923](https://bugs.openjdk.org/browse/JDK-8299923): Specify coordinate order for additional CaptureCallState parameters on class as well (**CSR**)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer) ⚠️ Review applies to [275d0cc1](https://git.openjdk.org/jdk20/pull/95/files/275d0cc17b2401404b64536f4f38c3ca8d9c4303)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [ab53c5a6](https://git.openjdk.org/jdk20/pull/95/files/ab53c5a6e8b8796fe2e0f96ddaaf4e907b4f28ee)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jdk20 pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/95.diff">https://git.openjdk.org/jdk20/pull/95.diff</a>

</details>
