### PR TITLE
8299891: JMX ObjectInputFilter additional classes needed

### DIFF
--- a/src/jdk.management.agent/share/conf/management.properties
+++ b/src/jdk.management.agent/share/conf/management.properties
@@ -302,6 +302,23 @@
 #   If the pattern ends with "*", it matches any class with the pattern as a prefix.
 #   If the pattern is equal to the class name, it matches.
 #   Otherwise, the status is UNDECIDED.
-com.sun.management.jmxremote.serial.filter.pattern=java.lang.*;java.math.BigInteger;java.math.BigDecimal;java.util.*;\
-javax.management.*;javax.management.openmbean.*;java.rmi.MarshalledObject;javax.security.auth.Subject;!*
+com.sun.management.jmxremote.serial.filter.pattern=\
+java.lang.*;\
+java.lang.reflect.Proxy;\
+java.math.BigInteger;
+java.math.BigDecimal;
+java.util.*;\
+javax.management.*;\
+javax.management.modelmbean.*;\
+javax.management.monitor.*;\
+javax.management.openmbean.*;\
+javax.management.relation.*;\
+javax.management.remote.*;\
+javax.management.remote.rmi.*;\
+javax.management.timer.*;\
+javax.rmi.ssl.*;\
+java.rmi.MarshalledObject;\
+java.rmi.dgc.*;\
+java.rmi.server.*;\
+javax.security.auth.Subject;!*
 

--- a/src/jdk.management.agent/share/conf/management.properties
+++ b/src/jdk.management.agent/share/conf/management.properties
@@ -302,11 +302,13 @@
 #   If the pattern ends with "*", it matches any class with the pattern as a prefix.
 #   If the pattern is equal to the class name, it matches.
 #   Otherwise, the status is UNDECIDED.
+#
+#   Ending with !* ensures we reject classes which are otherwise unmatched.
 com.sun.management.jmxremote.serial.filter.pattern=\
 java.lang.*;\
 java.lang.reflect.Proxy;\
-java.math.BigInteger;
-java.math.BigDecimal;
+java.math.BigInteger;\
+java.math.BigDecimal;\
 java.util.*;\
 javax.management.*;\
 javax.management.modelmbean.*;\
@@ -320,5 +322,6 @@ javax.rmi.ssl.*;\
 java.rmi.MarshalledObject;\
 java.rmi.dgc.*;\
 java.rmi.server.*;\
-javax.security.auth.Subject;!*
+javax.security.auth.Subject;\
+!*
 

--- a/src/jdk.management.agent/share/conf/management.properties
+++ b/src/jdk.management.agent/share/conf/management.properties
@@ -302,5 +302,6 @@
 #   If the pattern ends with "*", it matches any class with the pattern as a prefix.
 #   If the pattern is equal to the class name, it matches.
 #   Otherwise, the status is UNDECIDED.
-com.sun.management.jmxremote.serial.filter.pattern=java.lang.*;java.math.BigInteger;java.math.BigDecimal;java.util.*;javax.management.openmbean.*;javax.management.ObjectName;java.rmi.MarshalledObject;javax.security.auth.Subject;!*
+com.sun.management.jmxremote.serial.filter.pattern=java.lang.*;java.math.BigInteger;java.math.BigDecimal;java.util.*;\
+javax.management.*;javax.management.openmbean.*;java.rmi.MarshalledObject;javax.security.auth.Subject;!*
 

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -235,8 +235,8 @@ public class DefaultAgentFilterTest {
     }
 
     /**
-      * Run the test app and connect. Test MBean Operations if the boolean testOperations is true, otherwise 
-      * test other usages (Attributes, Query).
+      * Run the test app and connect. Test MBean Operations if the boolean testOperations is true, otherwise
+      * test other usages (Attributes, Query)
       */
     private static void testDefaultAgent(String propertyFile, String additionalArgument, int port, boolean testOperations) throws Exception {
         List<String> pbArgs = new ArrayList<>(Arrays.asList(

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -241,8 +241,9 @@ public class DefaultAgentFilterTest {
     private static void testDefaultAgent(String propertyFile, String additionalArgument, boolean testOperations) throws Exception {
         for (int i = 1; i <= FREE_PORT_ATTEMPTS; i++) {
             int port = Utils.getFreePort();
-            System.out.println("Attempting testDefaultAgent(" +
-                               (propertyFile != null ? propertyFile : "no properties")
+            System.out.println("Attempting testDefaultAgent("
+                               + (propertyFile != null ? propertyFile : "no properties")
+                               + " testOperations=" + testOperations
                                + ") with port: " + port);
             try {
                 testDefaultAgent(propertyFile, additionalArgument, port, testOperations);
@@ -337,7 +338,7 @@ public class DefaultAgentFilterTest {
         System.out.println("---" + DefaultAgentFilterTest.class.getName() + "-main: starting ...");
 
         try {
-            // filter DefaultAgentFilterTest$MyTestObject
+            // Properties file filter blocks DefaultAgentFilterTest$MyTestObject
             testDefaultAgent("mgmt1.properties");
             System.out.println("----\tTest FAILED !!");
             throw new RuntimeException("---" + DefaultAgentFilterTest.class.getName() + " - No exception reported");

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -423,7 +423,7 @@ public class DefaultAgentFilterTest {
             }
 
             // Use javax.management.AttributeList:
-            AttributeList attrs = conn.getAttributes(name, new String [] { "MyAttribute", "MyAttribute2" }); 
+            AttributeList attrs = conn.getAttributes(name, new String [] { "MyAttribute", "MyAttribute2" });
             attrs = conn.setAttributes(name, attrs); // Setting fails if filter too restrictive
 
             // Sending a Query uses several classes from javax.management:

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -143,6 +143,7 @@ public class DefaultAgentFilterTest {
 
         @Override
         public MBeanNotificationInfo[] getNotificationInfo() {
+            System.out.println("Invoked getNotificationInfo");
             String[] types = new String[] { AttributeChangeNotification.ATTRIBUTE_CHANGE };
             String name = AttributeChangeNotification.class.getName();
             String description = "An attribute of this MBean has changed";

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
  /*
  * @test
- * @bug 8159377 8283093
+ * @bug 8159377 8283093 8299891
  * @library /test/lib
  * @summary Tests ObjectFilter on default agent
  * @author Harsha Wardhana B
@@ -48,9 +48,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.management.Attribute;
+import javax.management.AttributeList;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.ObjectInstance;
+import javax.management.Query;
+import javax.management.QueryExp;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
@@ -73,9 +79,20 @@ public class DefaultAgentFilterTest {
         public void op2(String s, HashSet<String> params);
 
         public void op3(MyTestObject obj, String s, HashMap<String, String> param);
+
+        public void setMyAttribute(boolean b);
+
+        public boolean getMyAttribute();
+
+        public void setMyAttribute2(String s);
+
+        public String getMyAttribute2();
     }
 
     public static class Test implements TestMBean {
+
+        boolean myAttribute;
+        String myAttribute2;
 
         @Override
         public void op1(HashSet<Object> params) {
@@ -90,6 +107,26 @@ public class DefaultAgentFilterTest {
         @Override
         public void op3(MyTestObject obj, String s, HashMap<String, String> param) {
             System.out.println("Invoked op3");
+        }
+
+        public void setMyAttribute(boolean b) {
+            this.myAttribute = b;
+            System.out.println("Invoked setMyAttribute");
+        }
+
+        public boolean getMyAttribute() {
+            System.out.println("Invoked getMyAttribute");
+            return myAttribute;
+        }
+
+        public void setMyAttribute2(String s) {
+            this.myAttribute2 = s;
+            System.out.println("Invoked setMyAttribute2");
+        }
+
+        public String getMyAttribute2() {
+            System.out.println("Invoked getMyAttribute2");
+            return myAttribute2;
         }
     }
 
@@ -171,18 +208,18 @@ public class DefaultAgentFilterTest {
     private static final String TEST_APP_NAME = "TestApp";
     private static final int FREE_PORT_ATTEMPTS = 10;
 
-    private static void testDefaultAgent(String propertyFile) throws Exception {
-        testDefaultAgent(propertyFile, null);
+    private static void testDefaultAgent(String propertyFile, boolean testAttributes) throws Exception {
+        testDefaultAgent(propertyFile, null, testAttributes);
     }
 
-    private static void testDefaultAgent(String propertyFile, String additionalArgument) throws Exception {
+    private static void testDefaultAgent(String propertyFile, String additionalArgument, boolean testAttributes) throws Exception {
         for (int i = 1; i <= FREE_PORT_ATTEMPTS; i++) {
             int port = Utils.getFreePort();
             System.out.println("Attempting testDefaultAgent(" +
                                (propertyFile != null ? propertyFile : "no properties")
                                + ") with port: " + port);
             try {
-                testDefaultAgent(propertyFile, additionalArgument, port);
+                testDefaultAgent(propertyFile, additionalArgument, port, testAttributes);
                 break;  // return succesfully
             } catch (BindException b) {
                 // Retry with new port.  Throw if last iteration:
@@ -193,7 +230,10 @@ public class DefaultAgentFilterTest {
         }
     }
 
-    private static void testDefaultAgent(String propertyFile, String additionalArgument, int port) throws Exception {
+    /**
+      * Run the test app and connect. Test MBean Operations, or, if the boolean testAttributes is true, test Attributes (set, get).
+      */
+    private static void testDefaultAgent(String propertyFile, String additionalArgument, int port, boolean testAttributes) throws Exception {
         List<String> pbArgs = new ArrayList<>(Arrays.asList(
                 "-cp",
                 System.getProperty("test.class.path"),
@@ -219,7 +259,11 @@ public class DefaultAgentFilterTest {
         try (TestAppRun s = new TestAppRun(pb, DefaultAgentFilterTest.class.getSimpleName())) {
             s.start();
             JMXServiceURL url = testConnect(port);
-            testMBeanOperations(url);
+            if (testAttributes) {
+                testMBeanAttributes(url);
+            } else {
+                testMBeanOperations(url);
+            }
         }
     }
 
@@ -267,7 +311,7 @@ public class DefaultAgentFilterTest {
 
         try {
             // filter DefaultAgentFilterTest$MyTestObject
-            testDefaultAgent("mgmt1.properties");
+            testDefaultAgent("mgmt1.properties", false);
             System.out.println("----\tTest FAILED !!");
             throw new RuntimeException("---" + DefaultAgentFilterTest.class.getName() + " - No exception reported");
         } catch (Exception ex) {
@@ -284,7 +328,7 @@ public class DefaultAgentFilterTest {
         }
         try {
             // filter non-existent class
-            testDefaultAgent("mgmt2.properties");
+            testDefaultAgent("mgmt2.properties", false);
             System.out.println("----\tTest PASSED !!");
         } catch (Exception ex) {
             System.out.println(ex);
@@ -293,7 +337,7 @@ public class DefaultAgentFilterTest {
         }
         try {
             // Use default filter, should fail with: java.io.InvalidClassException: filter status: REJECTED
-            testDefaultAgent(null /* no properties file */);
+            testDefaultAgent(null /* no properties file */, false);
             throw new RuntimeException("---" + DefaultAgentFilterTest.class.getName() + " - No exception reported");
         } catch (Exception ex) {
             System.out.println(ex);
@@ -305,10 +349,18 @@ public class DefaultAgentFilterTest {
             }
         }
         try {
+            // Test Attributes work by default:
+            testDefaultAgent(null /* no properties file */, true);
+        } catch (Exception ex) {
+            System.out.println(ex);
+            System.out.println("----\tTest FAILED !!");
+            throw ex;
+        }
+        try {
             // Add custom filter on command-line.
             testDefaultAgent(null, "-Dcom.sun.management.jmxremote.serial.filter.pattern=\"java.lang.*;java.math.BigInteger;"
                              + "java.math.BigDecimal;java.util.*;javax.management.openmbean.*;javax.management.ObjectName;"
-                             + "java.rmi.MarshalledObject;javax.security.auth.Subject;DefaultAgentFilterTest$MyTestObject;!*\"");
+                             + "java.rmi.MarshalledObject;javax.security.auth.Subject;DefaultAgentFilterTest$MyTestObject;!*\"", false);
             System.out.println("----\tTest PASSED: with custom filter on command-line");
         } catch (Exception ex) {
             System.out.println(ex);
@@ -346,6 +398,39 @@ public class DefaultAgentFilterTest {
             String[] sig3 = {MyTestObject.class.getName(), String.class.getName(),
                 HashMap.class.getName()};
             conn.invoke(name, "op3", params3, sig3);
+
+            System.out.println("Done testMBeanOperations");
+        }
+    }
+
+    private static void testMBeanAttributes(JMXServiceURL serverUrl) throws Exception {
+        Map<String, Object> clientEnv = new HashMap<>(1);
+        ObjectName name = new ObjectName("jtreg:type=Test");
+        try (JMXConnector client = JMXConnectorFactory.connect(serverUrl, clientEnv)) {
+            MBeanServerConnection conn = client.getMBeanServerConnection();
+
+            // Set operations send types to the server and can conflict with the filter.
+            // Attribute set operations require javax.management.Attribute.
+            conn.setAttribute(name, new Attribute("MyAttribute", Boolean.TRUE));
+            boolean b = (Boolean) conn.getAttribute(name, "MyAttribute");
+            if (b != true) {
+                throw new RuntimeException("Attribute not as expected, got: " + b);
+            }
+            conn.setAttribute(name, new Attribute("MyAttribute2", "my string value"));
+            String s = (String) conn.getAttribute(name, "MyAttribute2");
+            if (!s.equals("my string value")) {
+                throw new RuntimeException("Attribute not as expected, got: " + s);
+            }
+
+            // Use javax.management.AttributeList:
+            AttributeList attrs = conn.getAttributes(name, new String [] { "MyAttribute", "MyAttribute2" }); 
+            attrs = conn.setAttributes(name, attrs); // Setting fails if filter too restrictive
+
+            // Sending a Query uses several classes from javax.management:
+            QueryExp exp = Query.isInstanceOf(Query.value("notImportantClassName"));
+            Set<ObjectInstance> queryResult = conn.queryMBeans(name, exp);
+
+            System.out.println("Done testMBeanAttributes");
         }
     }
 }


### PR DESCRIPTION
The default setting for the ObjectInputFilter for JMX, introduced in jdk20, is too restrictive.
javax.management.Attribute and AttributeList classes are also needed, and Query related classes.

There are a number of Query-related classes, so adding javax.management.* is appropriate otherwise the list becomes hard to manage.  This is a * and not a ** which would mean all subpackages, so the openmean subpackage stays in the list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8300581](https://bugs.openjdk.org/browse/JDK-8300581) to be approved

### Issues
 * [JDK-8299891](https://bugs.openjdk.org/browse/JDK-8299891): JMX ObjectInputFilter additional classes needed
 * [JDK-8300581](https://bugs.openjdk.org/browse/JDK-8300581): JMX ObjectInputFilter additional classes needed (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [ab81891d](https://git.openjdk.org/jdk20/pull/97/files/ab81891ddec0b8418e24311194114faa6c1d6b7b)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jdk20 pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/97.diff">https://git.openjdk.org/jdk20/pull/97.diff</a>

</details>
