### PR TITLE
8299034: Runtime::exec clarification of inherited environment

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessBuilder.java
+++ b/src/java.base/share/classes/java/lang/ProcessBuilder.java
@@ -1004,6 +1004,8 @@ public final class ProcessBuilder
      * be required to start a process on some operating systems.
      * As a result, the subprocess may inherit additional environment variable
      * settings beyond those in the process builder's {@link #environment()}.
+     * The minimal set of system dependent environment variables
+     * may override the values provided in the environment.
      *
      * <p>If there is a security manager, its
      * {@link SecurityManager#checkExec checkExec}
@@ -1181,6 +1183,8 @@ public final class ProcessBuilder
      * be required to start a process on some operating systems.
      * As a result, the subprocess may inherit additional environment variable
      * settings beyond those in the process builder's {@link #environment()}.
+     * The minimal set of system dependent environment variables
+     * may override the values provided in the environment.
      * <p>
      * If there is a security manager, its
      * {@link SecurityManager#checkExec checkExec}

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -569,6 +569,8 @@ public class Runtime {
      * be required to start a process on some operating systems.
      * As a result, the subprocess may inherit additional environment variable
      * settings beyond those in the specified environment.
+     * The minimal set of system dependent environment variables
+     * may override the values provided in the environment.
      *
      * <p>{@link ProcessBuilder#start()} is now the preferred way to
      * start a process with a modified environment.


### PR DESCRIPTION
The current description of Runtime.exec, ProcessBuilder.start, and ProcessBuilder.startPipeline identifies a minimum set of system dependent environment variables needed to launch a process and allows additional system dependent environment variables to be present in the child. However, it does not acknowledge that the parent's values of the minimum set of system dependent variables may not be appropriate for the child.

The description of the minimum set of system dependent environment variables is extended to allow the parent's values of those environment variables to be overridden in the child.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8299034](https://bugs.openjdk.org/browse/JDK-8299034): Runtime::exec clarification of inherited environment
 * [JDK-8299157](https://bugs.openjdk.org/browse/JDK-8299157): Runtime::exec clarification of inherited environment (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jdk20 pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/98.diff">https://git.openjdk.org/jdk20/pull/98.diff</a>

</details>
