### PR TITLE
8298400: Virtual thread instability when stack overflows

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1218,6 +1218,17 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
     __ bind(pinned); // pinned -- return to caller
 
+
+
+    // handle pending exception thrown by freeze
+    __ ldr(rscratch1, Address(rthread, in_bytes(Thread::pending_exception_offset())));
+    Label ok;
+    __ cbz(rscratch1, ok);
+    __ leave();
+    __ lea(rscratch1, RuntimeAddress(StubRoutines::forward_exception_entry()));
+    __ br(rscratch1);
+    __ bind(ok);
+
     __ leave();
     __ ret(lr);
 

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1218,8 +1218,6 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
     __ bind(pinned); // pinned -- return to caller
 
-
-
     // handle pending exception thrown by freeze
     __ ldr(rscratch1, Address(rthread, in_bytes(Thread::pending_exception_offset())));
     Label ok;

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1990,6 +1990,19 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   __ bind(L_pinned); // pinned -- return to caller
 
+  // handle pending exception thrown by freeze
+  Label ok;
+  __ ld(tmp, in_bytes(JavaThread::pending_exception_offset()), R16_thread);
+  __ cmpdi(CCR0, tmp, 0);
+  __ beq(CCR0, ok);
+  __ pop_frame();
+  __ ld(R0, _abi0(lr), R1_SP); // Return pc
+  __ mtlr(R0);
+  __ load_const_optimized(tmp, StubRoutines::forward_exception_entry(), R0);
+  __ mtctr(tmp);
+  __ bctr();
+  __ bind(ok);
+
   // Pop frame and return
   __ pop_frame();
   __ ld(R0, _abi0(lr), R1_SP); // Return pc

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1095,6 +1095,15 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   __ bind(pinned); // pinned -- return to caller
 
+  // handle pending exception thrown by freeze
+  __ ld(t0, Address(xthread, in_bytes(Thread::pending_exception_offset())));
+  Label ok;
+  __ beqz(t0, ok);
+  __ leave();
+  __ la(t0, RuntimeAddress(StubRoutines::forward_exception_entry()));
+  __ jr(t0);
+  __ bind(ok);
+
   __ leave();
   __ ret();
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1587,6 +1587,15 @@ static void gen_continuation_yield(MacroAssembler* masm,
   __ bind(L_pinned);
 
   // Pinned, return to caller
+
+  // handle pending exception thrown by freeze
+  __ cmpptr(Address(r15_thread, Thread::pending_exception_offset()), NULL_WORD);
+  Label ok;
+  __ jcc(Assembler::equal, ok);
+  __ leave();
+  __ jump(RuntimeAddress(StubRoutines::forward_exception_entry()));
+  __ bind(ok);
+
   __ leave();
   __ ret(0);
 }

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -274,7 +274,7 @@ public:
 static bool stack_overflow_check(JavaThread* thread, int size, address sp) {
   const int page_size = os::vm_page_size();
   if (size > page_size) {
-    if (sp - size < thread->stack_overflow_state()->stack_overflow_limit()) {
+    if (sp - size < thread->stack_overflow_state()->shadow_zone_safe_limit()) {
       return false;
     }
   }
@@ -1259,7 +1259,7 @@ NOINLINE void FreezeBase::finish_freeze(const frame& f, const frame& top) {
 inline bool FreezeBase::stack_overflow() { // detect stack overflow in recursive native code
   JavaThread* t = !_preempt ? _thread : JavaThread::current();
   assert(t == JavaThread::current(), "");
-  if (os::current_stack_pointer() < t->stack_overflow_state()->stack_overflow_limit()) {
+  if (os::current_stack_pointer() < t->stack_overflow_state()->shadow_zone_safe_limit()) {
     if (!_preempt) {
       ContinuationWrapper::SafepointOp so(t, _cont); // could also call _cont.done() instead
       Exceptions::_throw_msg(t, __FILE__, __LINE__, vmSymbols::java_lang_StackOverflowError(), "Stack overflow while freezing");


### PR DESCRIPTION
The stack overflow is detected in the native code and a pending exception is set, but it is not thrown.

Additionally, the stack overflow detection is changed use StackOverflow::shadow_zone_safe_limit rather than StackOverflow::stack_overflow_limit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298400](https://bugs.openjdk.org/browse/JDK-8298400): Virtual thread instability when stack overflows


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [f48e48c6](https://git.openjdk.org/jdk20/pull/101/files/f48e48c6d40b211ede310ed91b90d7b38c42399f)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [cd05ad8c](https://git.openjdk.org/jdk20/pull/101/files/cd05ad8ca694cd0f418a92e712801a3b45a7b416)


### Contributors
 * Fei Yang `<fyang@openjdk.org>`
 * Richard Reingruber `<rrich@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/jdk20 pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/101.diff">https://git.openjdk.org/jdk20/pull/101.diff</a>

</details>
