### PR TITLE
8300055: [BACKOUT] OPEN_MAX is no longer the max limit on macOS >= 10.6 for RLIMIT_NOFILE

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1969,18 +1969,15 @@ jint os::init_2(void) {
       log_info(os)("os::init_2 getrlimit failed: %s", os::strerror(errno));
     } else {
       nbr_files.rlim_cur = nbr_files.rlim_max;
-      status = setrlimit(RLIMIT_NOFILE, &nbr_files);
+
 #ifdef __APPLE__
-      if (status != 0 && errno == EINVAL) {
-        // On macOS >= 10.6 if we define _DARWIN_UNLIMITED_STREAMS or _DARWIN_C_SOURCE
-        // (we define _DARWIN_C_SOURCE) we can ask for RLIM_INFINITY,
-        // however, on macOS < 10.6 Darwin returns RLIM_INFINITY for rlim_max,
-        // but fails with EINVAL if you attempt to use RLIM_INFINITY.
-        // As per setrlimit(2), OPEN_MAX must be used instead.
-        nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
-        status = setrlimit(RLIMIT_NOFILE, &nbr_files);
-      }
-#endif // __APPLE__
+      // Darwin returns RLIM_INFINITY for rlim_max, but fails with EINVAL if
+      // you attempt to use RLIM_INFINITY. As per setrlimit(2), OPEN_MAX must
+      // be used instead
+      nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
+#endif
+
+      status = setrlimit(RLIMIT_NOFILE, &nbr_files);
       if (status != 0) {
         log_info(os)("os::init_2 setrlimit failed: %s", os::strerror(errno));
       }


### PR DESCRIPTION
This is a **backout** of [JDK-8291060 OPEN_MAX is no longer the max limit on macOS >= 10.6 for RLIMIT_NOFILE](https://bugs.openjdk.org/browse/JDK-8291060) which triggered a bug in ksh, resulting in a crash.

Verified with test case from https://bugs.openjdk.org/browse/JDK-8299258 and running Mach5 hs-tier1,2,3,4,5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300055](https://bugs.openjdk.org/browse/JDK-8300055): [BACKOUT] OPEN_MAX is no longer the max limit on macOS >= 10.6 for RLIMIT_NOFILE


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.org/jdk20 pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/102.diff">https://git.openjdk.org/jdk20/pull/102.diff</a>

</details>
