### PR TITLE
8300141: ProblemList java/util/concurrent/locks/Lock/OOMEInAQS.java with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -29,6 +29,7 @@
 
 vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8277573 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
+vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -50,4 +50,5 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter001/TestDescription.java 8298059 generic-x64
 vmTestbase/nsk/jdi/ExceptionRequest/addInstanceFilter/instancefilter004/TestDescription.java 8298059 generic-x64
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
+vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64
 vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java 8298596 linux-x64

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,3 +28,4 @@
 #############################################################################
 
 jdk/internal/vm/Continuation/Fuzz.java#default 8298058 generic-x64
+java/util/concurrent/locks/Lock/OOMEInAQS.java 8298066 windows-x64


### PR DESCRIPTION
Trivial fixes to ProblemList some tests:
[JDK-8300141](https://bugs.openjdk.org/browse/JDK-8300141) ProblemList java/util/concurrent/locks/Lock/OOMEInAQS.java with ZGC
[JDK-8300144](https://bugs.openjdk.org/browse/JDK-8300144) ProblemList vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java with ZGC
[JDK-8300147](https://bugs.openjdk.org/browse/JDK-8300147) ProblemList vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java in Xcomp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8300141](https://bugs.openjdk.org/browse/JDK-8300141): ProblemList java/util/concurrent/locks/Lock/OOMEInAQS.java with ZGC
 * [JDK-8300144](https://bugs.openjdk.org/browse/JDK-8300144): ProblemList vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java with ZGC
 * [JDK-8300147](https://bugs.openjdk.org/browse/JDK-8300147): ProblemList vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java in Xcomp


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.org/jdk20 pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/103.diff">https://git.openjdk.org/jdk20/pull/103.diff</a>

</details>
