### PR TITLE
8299498: Usage of constructors of primitive wrapper classes should be avoided in java.lang API docs

### DIFF
--- a/src/java.base/share/classes/java/lang/ArrayStoreException.java
+++ b/src/java.base/share/classes/java/lang/ArrayStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ package java.lang;
  * following code generates an {@code ArrayStoreException}:
  * <blockquote><pre>
  *     Object x[] = new String[3];
- *     x[0] = new Integer(0);
+ *     x[0] = Integer.valueOf(0);
  * </pre></blockquote>
  *
  * @since   1.0

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,7 +233,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
      * equal to the value of:
      *
      * <blockquote>
-     * {@code new Byte(Byte.parseByte(s, radix))}
+     * {@code Byte.valueOf(Byte.parseByte(s, radix))}
      * </blockquote>
      *
      * @param s         the string to be parsed
@@ -262,7 +262,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
      * equal to the value of:
      *
      * <blockquote>
-     * {@code new Byte(Byte.parseByte(s))}
+     * {@code Byte.valueOf(Byte.parseByte(s))}
      * </blockquote>
      *
      * @param s         the string to be parsed

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1260,7 +1260,7 @@ public final class Double extends Number
      * of the integer value returned is the same as that of the
      * integer that would be returned by the call:
      * <pre>
-     *    new Double(d1).compareTo(new Double(d2))
+     *    Double.valueOf(d1).compareTo(Double.valueOf(d2))
      * </pre>
      *
      * @param   d1        the first {@code double} to compare

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1218,7 +1218,7 @@ public final class Float extends Number
      * of the integer value returned is the same as that of the
      * integer that would be returned by the call:
      * <pre>
-     *    new Float(f1).compareTo(new Float(f2))
+     *    Float.valueOf(f1).compareTo(Float.valueOf(f2))
      * </pre>
      *
      * @param   f1        the first {@code float} to compare.

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -951,7 +951,7 @@ public final class Integer extends Number
      * object equal to the value of:
      *
      * <blockquote>
-     *  {@code new Integer(Integer.parseInt(s, radix))}
+     *  {@code Integer.valueOf(Integer.parseInt(s, radix))}
      * </blockquote>
      *
      * @param      s   the string to be parsed.
@@ -979,7 +979,7 @@ public final class Integer extends Number
      * object equal to the value of:
      *
      * <blockquote>
-     *  {@code new Integer(Integer.parseInt(s))}
+     *  {@code Integer.valueOf(Integer.parseInt(s))}
      * </blockquote>
      *
      * @param      s   the string to be parsed.
@@ -1286,14 +1286,14 @@ public final class Integer extends Number
      * equal to the value of:
      *
      * <blockquote>
-     *  {@code getInteger(nm, new Integer(val))}
+     *  {@code getInteger(nm, Integer.valueOf(val))}
      * </blockquote>
      *
      * but in practice it may be implemented in a manner such as:
      *
      * <blockquote><pre>
      * Integer result = getInteger(nm, null);
-     * return (result == null) ? new Integer(val) : result;
+     * return (result == null) ? Integer.valueOf(val) : result;
      * </pre></blockquote>
      *
      * to avoid the unnecessary allocation of an {@code Integer}

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1114,7 +1114,7 @@ public final class Long extends Number
      * to the value of:
      *
      * <blockquote>
-     *  {@code new Long(Long.parseLong(s, radix))}
+     *  {@code Long.valueOf(Long.parseLong(s, radix))}
      * </blockquote>
      *
      * @param      s       the string to be parsed
@@ -1142,7 +1142,7 @@ public final class Long extends Number
      * equal to the value of:
      *
      * <blockquote>
-     *  {@code new Long(Long.parseLong(s))}
+     *  {@code Long.valueOf(Long.parseLong(s))}
      * </blockquote>
      *
      * @param      s   the string to be parsed.
@@ -1509,14 +1509,14 @@ public final class Long extends Number
      * to the value of:
      *
      * <blockquote>
-     *  {@code getLong(nm, new Long(val))}
+     *  {@code getLong(nm, Long.valueOf(val))}
      * </blockquote>
      *
      * but in practice it may be implemented in a manner such as:
      *
      * <blockquote><pre>
      * Long result = getLong(nm, null);
-     * return (result == null) ? new Long(val) : result;
+     * return (result == null) ? Long.valueOf(val) : result;
      * </pre></blockquote>
      *
      * to avoid the unnecessary allocation of a {@code Long} object when

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
      * equal to the value of:
      *
      * <blockquote>
-     *  {@code new Short(Short.parseShort(s, radix))}
+     *  {@code Short.valueOf(Short.parseShort(s, radix))}
      * </blockquote>
      *
      * @param s         the string to be parsed
@@ -206,7 +206,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
      * equal to the value of:
      *
      * <blockquote>
-     *  {@code new Short(Short.parseShort(s))}
+     *  {@code Short.valueOf(Short.parseShort(s))}
      * </blockquote>
      *
      * @param s the string to be parsed


### PR DESCRIPTION
This pull request contains a backport of commit [d663b5da](https://github.com/openjdk/jdk/commit/d663b5da10be1f3f33a2729e4b3605fb5e13b4d6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Justin Lu on 11 Jan 2023 and was reviewed by Naoto Sato, Joe Darcy, Roger Riggs, Mandy Chung and Lance Andersen.

Thank you

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299498](https://bugs.openjdk.org/browse/JDK-8299498): Usage of constructors of primitive wrapper classes should be avoided in java.lang API docs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/jdk20 pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/104.diff">https://git.openjdk.org/jdk20/pull/104.diff</a>

</details>
