### PR TITLE
8299501: Usage of constructors of primitive wrapper classes should be avoided in java.util API docs

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2793,7 +2793,7 @@ public class Arrays {
      * two array references are considered equal if both are {@code null}.
      *
      * Two doubles {@code d1} and {@code d2} are considered equal if:
-     * <pre>    {@code new Double(d1).equals(new Double(d2))}</pre>
+     * <pre>    {@code Double.valueOf(d1).equals(Double.valueOf(d2))}</pre>
      * (Unlike the {@code ==} operator, this method considers
      * {@code NaN} equal to itself, and 0.0d unequal to -0.0d.)
      *
@@ -2826,7 +2826,7 @@ public class Arrays {
      * in the same order.
      *
      * <p>Two doubles {@code d1} and {@code d2} are considered equal if:
-     * <pre>    {@code new Double(d1).equals(new Double(d2))}</pre>
+     * <pre>    {@code Double.valueOf(d1).equals(Double.valueOf(d2))}</pre>
      * (Unlike the {@code ==} operator, this method considers
      * {@code NaN} equal to itself, and 0.0d unequal to -0.0d.)
      *
@@ -2876,7 +2876,7 @@ public class Arrays {
      * two array references are considered equal if both are {@code null}.
      *
      * Two floats {@code f1} and {@code f2} are considered equal if:
-     * <pre>    {@code new Float(f1).equals(new Float(f2))}</pre>
+     * <pre>    {@code Float.valueOf(f1).equals(Float.valueOf(f2))}</pre>
      * (Unlike the {@code ==} operator, this method considers
      * {@code NaN} equal to itself, and 0.0f unequal to -0.0f.)
      *
@@ -2909,7 +2909,7 @@ public class Arrays {
      * in the same order.
      *
      * <p>Two floats {@code f1} and {@code f2} are considered equal if:
-     * <pre>    {@code new Float(f1).equals(new Float(f2))}</pre>
+     * <pre>    {@code Float.valueOf(f1).equals(Float.valueOf(f2))}</pre>
      * (Unlike the {@code ==} operator, this method considers
      * {@code NaN} equal to itself, and 0.0f unequal to -0.0f.)
      *


### PR DESCRIPTION
This pull request contains a backport of commit [f36f1354](https://github.com/openjdk/jdk/commit/f36f1354c63a500c70ae51a9c2b2d21ad55cfa77) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Justin Lu on 9 Jan 2023 and was reviewed by Naoto Sato and Lance Andersen.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299501](https://bugs.openjdk.org/browse/JDK-8299501): Usage of constructors of primitive wrapper classes should be avoided in java.util API docs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/jdk20 pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/105.diff">https://git.openjdk.org/jdk20/pull/105.diff</a>

</details>
