### PR TITLE
8299500: Usage of constructors of primitive wrapper classes should be avoided in java.text API docs

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ import java.util.Arrays;
  * pattform.setFormats(testFormats);
  * Object[] testArgs = {null, "ADisk", null};
  * for (int i = 0; i < 4; ++i) {
- *     testArgs[0] = new Integer(i);
+ *     testArgs[0] = Integer.valueOf(i);
  *     testArgs[2] = testArgs[0];
  *     System.out.println(pattform.format(testArgs));
  * }

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,7 +249,7 @@ import java.util.Locale;
  * <blockquote><pre>
  * int fileCount = 1273;
  * String diskName = "MyDisk";
- * Object[] testArgs = {new Long(fileCount), diskName};
+ * Object[] testArgs = {Long.valueOf(fileCount), diskName};
  *
  * MessageFormat form = new MessageFormat(
  *     "The disk \"{1}\" contains {0} file(s).");
@@ -275,7 +275,7 @@ import java.util.Locale;
  *
  * int fileCount = 1273;
  * String diskName = "MyDisk";
- * Object[] testArgs = {new Long(fileCount), diskName};
+ * Object[] testArgs = {Long.valueOf(fileCount), diskName};
  *
  * System.out.println(form.format(testArgs));
  * </pre></blockquote>
@@ -307,12 +307,11 @@ import java.util.Locale;
  * will be the final result of the parsing.  For example,
  * <blockquote><pre>
  * MessageFormat mf = new MessageFormat("{0,number,#.##}, {0,number,#.#}");
- * Object[] objs = {new Double(3.1415)};
+ * Object[] objs = {Double.valueOf(3.1415)};
  * String result = mf.format( objs );
  * // result now equals "3.14, 3.1"
- * objs = null;
  * objs = mf.parse(result, new ParsePosition(0));
- * // objs now equals {new Double(3.1)}
+ * // objs now equals {Double.valueOf(3.1)}
  * </pre></blockquote>
  *
  * <p>


### PR DESCRIPTION
This pull request contains a backport of commit [cd10c727](https://github.com/openjdk/jdk/commit/cd10c7278d8fcf7ce6713a3ee688bb1e10c024f6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Justin Lu on 9 Jan 2023 and was reviewed by Naoto Sato and Lance Andersen.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299500](https://bugs.openjdk.org/browse/JDK-8299500): Usage of constructors of primitive wrapper classes should be avoided in java.text API docs


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jdk20 pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/106.diff">https://git.openjdk.org/jdk20/pull/106.diff</a>

</details>
