### PR TITLE
8299502: Usage of constructors of primitive wrapper classes should be avoided in javax.xml API docs

### DIFF
--- a/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLOutputFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ import javax.xml.transform.Result;
  * <p>The following paragraphs describe the namespace and prefix repair algorithm:
  *
  * <p>The property can be set with the following code line:
- * {@code setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true|false));}
+ * {@code setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);}
  *
  * <p>This property specifies that the writer default namespace prefix declarations.
  * The default value is false.


### PR DESCRIPTION
This pull request contains a backport of commit [b8852f65](https://github.com/openjdk/jdk/commit/b8852f65a0adcb9ee5693bb6727a0668aa9808bf) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Justin Lu on 9 Jan 2023 and was reviewed by Joe Wang, Naoto Sato and Lance Andersen.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299502](https://bugs.openjdk.org/browse/JDK-8299502): Usage of constructors of primitive wrapper classes should be avoided in javax.xml API docs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/jdk20 pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/107.diff">https://git.openjdk.org/jdk20/pull/107.diff</a>

</details>
