### PR TITLE
8299499: Usage of constructors of primitive wrapper classes should be avoided in java.net API docs

### DIFF
--- a/src/java.base/share/classes/java/net/SocketOptions.java
+++ b/src/java.base/share/classes/java/net/SocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,9 +54,9 @@ public interface SocketOptions {
      * <BR><PRE>
      * SocketImpl s;
      * ...
-     * s.setOption(SO_LINGER, new Integer(10));
+     * s.setOption(SO_LINGER, Integer.valueOf(10));
      *    // OK - set SO_LINGER w/ timeout of 10 sec.
-     * s.setOption(SO_LINGER, new Double(10));
+     * s.setOption(SO_LINGER, Double.valueOf(10));
      *    // ERROR - expects java.lang.Integer
      *</PRE>
      * If the requested option is binary, it can be set using this method by


### PR DESCRIPTION
This pull request contains a backport of commit [63cf4aa0](https://github.com/openjdk/jdk/commit/63cf4aa0c897406fc9370a8e05cb035caafc5d69) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Justin Lu on 7 Jan 2023 and was reviewed by Naoto Sato and Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299499](https://bugs.openjdk.org/browse/JDK-8299499): Usage of constructors of primitive wrapper classes should be avoided in java.net API docs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/jdk20 pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/108.diff">https://git.openjdk.org/jdk20/pull/108.diff</a>

</details>
