### PR TITLE
8300953: ClassDesc::ofInternalName missing @since tag

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -99,6 +99,7 @@ public sealed interface ClassDesc
      * @jvms 4.2.1 Binary Class and Interface Names
      * @see ClassDesc#of(String)
      * @see ClassDesc#ofDescriptor(String)
+     * @since 20
      */
     static ClassDesc ofInternalName(String name) {
         ConstantUtils.validateInternalClassName(requireNonNull(name));


### PR DESCRIPTION
ClassDesc::ofInternalName was added in JDK 20, however @since tag is missing. 
This patch fixes the javadoc. 

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300953](https://bugs.openjdk.org/browse/JDK-8300953): ClassDesc::ofInternalName missing @since tag


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.org/jdk20 pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/115.diff">https://git.openjdk.org/jdk20/pull/115.diff</a>

</details>
