### PR TITLE
8301863: ObjectInputFilter example incorrectly calls rejectUndecidedClass

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -187,7 +187,7 @@ import static java.lang.System.Logger.Level.ERROR;
  *
  * This class shows how an application provided filter factory can combine filters
  * to check every deserialization operation that takes place in a thread.
- * It defines a thread-local variable to hold the thread-specific filter, and constructs a filter factory
+ * It defines a thread-local variable to hold the thread-specific filter, and construct a filter factory
  * that composes that filter with the static JVM-wide filter and the stream-specific filter,
  * rejecting any classes not handled by those two filters.
  * If a stream specific filter is set and does not accept or reject a class,

--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -188,7 +188,10 @@ import static java.lang.System.Logger.Level.ERROR;
  * This class shows how an application provided filter factory can combine filters
  * to check every deserialization operation that takes place in a thread.
  * It defines a thread-local variable to hold the thread-specific filter, and constructs a filter factory
- * that composes that filter with the static JVM-wide filter and the stream-specific filter.
+ * that composes that filter with the static JVM-wide filter and the stream-specific filter,
+ * rejecting any classes not handled by those two filters.
+ * If a stream specific filter is set and does not accept or reject a class,
+ * the combined JVM-wide filter and thread filter is applied.
  * The {@code doWithSerialFilter} method does the setup of the thread-specific filter
  * and invokes the application provided {@link Runnable Runnable}.
  *
@@ -207,26 +210,18 @@ import static java.lang.System.Logger.Level.ERROR;
  *             // Called from the OIS constructor or perhaps OIS.setObjectInputFilter with no current filter
  *             var filter = filterThreadLocal.get();
  *             if (filter != null) {
- *                 // Wrap the filter to reject UNDECIDED results
- *                 filter = ObjectInputFilter.rejectUndecidedClass(filter);
+ *                 // Merge to invoke the thread local filter and then the JVM-wide filter (if any)
+ *                 filter = ObjectInputFilter.merge(filter, next);
+ *                 return ObjectInputFilter.rejectUndecidedClass(filter);
  *             }
- *             if (next != null) {
- *                 // Merge the next filter with the thread filter, if any
- *                 // Initially this is the static JVM-wide filter passed from the OIS constructor
- *                 // Wrap the filter to reject UNDECIDED results
- *                 filter = ObjectInputFilter.merge(next, filter);
- *                 filter = ObjectInputFilter.rejectUndecidedClass(filter);
- *             }
- *             return filter;
+ *             return (next == null) ? null : ObjectInputFilter.rejectUndecidedClass(next);
  *         } else {
  *             // Called from OIS.setObjectInputFilter with a current filter and a stream-specific filter.
  *             // The curr filter already incorporates the thread filter and static JVM-wide filter
  *             // and rejection of undecided classes
- *             // If there is a stream-specific filter wrap it and a filter to recheck for undecided
+ *             // If there is a stream-specific filter merge to invoke it and then the current filter.
  *             if (next != null) {
- *                 next = ObjectInputFilter.merge(next, curr);
- *                 next = ObjectInputFilter.rejectUndecidedClass(next);
- *                 return next;
+ *                 return ObjectInputFilter.merge(next, curr);
  *             }
  *             return curr;
  *         }


### PR DESCRIPTION
The example code in ObjectInputFilter for the FilterInThread filter factory does not do what is intended and is poorly described. Clarifies that the JVM-wide filter and the thread local filter are merged and will reject classes that are otherwise not accepted or rejected. If a stream specific filter is set and does not accept or reject a class, the combined filter is applied.

This is a doc-only change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301863](https://bugs.openjdk.org/browse/JDK-8301863): ObjectInputFilter example incorrectly calls rejectUndecidedClass


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk20 pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jdk20 pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk20/pull/121.diff">https://git.openjdk.org/jdk20/pull/121.diff</a>

</details>
